### PR TITLE
Region specific neutron config

### DIFF
--- a/europe-example-region/templates/neutron/neutron-etc-region-configmap.yaml
+++ b/europe-example-region/templates/neutron/neutron-etc-region-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: neutron-etc-region
+  labels:
+    system: openstack
+    type: configuration
+    component: neutron
+
+
+data:
+  ml2-conf-aci.ini: |
+    [ml2_aci]
+
+

--- a/neutron/templates/aci-agent-deployment.yaml
+++ b/neutron/templates/aci-agent-deployment.yaml
@@ -46,6 +46,8 @@ spec:
               name: development
             - mountPath: /neutron-etc
               name: neutron-etc
+            - mountPath: /neutron-etc-region
+              name: neutron-etc-region
             - mountPath: /container.init
               name: container-init
       volumes:
@@ -55,6 +57,9 @@ spec:
         - name: neutron-etc
           configMap:
             name: neutron-etc
+        - name: neutron-etc-region
+          configMap:
+            name: neutron-etc-region
         - name: container-init
           configMap:
             name: neutron-bin

--- a/neutron/templates/bin/_neutron-aci-agent-start.tpl
+++ b/neutron/templates/bin/_neutron-aci-agent-start.tpl
@@ -9,7 +9,7 @@ function process_config {
     cp /neutron-etc/neutron.conf  /etc/neutron/neutron.conf
     cp /neutron-etc/logging.conf  /etc/neutron/logging.conf
     cp /neutron-etc/ml2-conf.ini  /etc/neutron/plugins/ml2/ml2_conf.ini
-    cp /neutron-etc/ml2-conf-aci.ini  /etc/neutron/plugins/ml2/ml2-conf-aci.ini
+    cp /neutron-etc-region/ml2-conf-aci.ini  /etc/neutron/plugins/ml2/ml2-conf-aci.ini
 }
 
 

--- a/neutron/templates/bin/_neutron-server-start.tpl
+++ b/neutron/templates/bin/_neutron-server-start.tpl
@@ -26,7 +26,7 @@ function process_config {
     cp /neutron-etc/neutron-lbaas.conf /etc/neutron/neutron_lbaas.conf
     cp /neutron-etc/ml2-conf.ini  /etc/neutron/plugins/ml2/ml2_conf.ini
 
-    cp /neutron-etc/ml2-conf-aci.ini  /etc/neutron/plugins/ml2/ml2-conf-aci.ini
+    cp /neutron-etc-region/ml2-conf-aci.ini  /etc/neutron/plugins/ml2/ml2-conf-aci.ini
 
     cp /neutron-etc/ml2-conf-arista.ini  /etc/neutron/plugins/ml2/ml2_conf_arista.ini
     cp /neutron-etc/ml2-conf-manila.ini  /etc/neutron/plugins/ml2/ml2_conf_manila.ini

--- a/neutron/templates/etc-configmap.yaml
+++ b/neutron/templates/etc-configmap.yaml
@@ -34,8 +34,6 @@ data:
 {{ tuple "etc/_ml2-conf-f5.ini.tpl" . | include "template" | indent 4 }}
   ml2-conf-manila.ini: |
 {{ tuple "etc/_ml2-conf-manila.ini.tpl" . | include "template" | indent 4 }}
-  ml2-conf-aci.ini: |
-{{ include "etc/neutron/ml2-conf-aci.ini" .| indent 4 }}
   neutron.conf: |
 {{ tuple "etc/_neutron.conf.tpl" . | include "template" | indent 4 }}
   neutron-lbaas.conf: |

--- a/neutron/templates/server-deployment.yaml
+++ b/neutron/templates/server-deployment.yaml
@@ -57,6 +57,8 @@ spec:
               name: development
             - mountPath: /neutron-etc
               name: neutron-etc
+            - mountPath: /neutron-etc-region
+              name: neutron-etc-region
             - mountPath: /neutron-patches
               name: neutron-patches
             - mountPath: /f5-patches
@@ -78,6 +80,9 @@ spec:
         - name: neutron-etc
           configMap:
             name: neutron-etc
+        - name: neutron-etc-region
+          configMap:
+            name: neutron-etc-region
         - name: neutron-patches
           configMap:
             name: neutron-patches


### PR DESCRIPTION
Short term workaround for us needing to inject region specific config files. This will be reviewed as we try to decouple our specific hardware/network requirements from a core openstack reference deployment