### PR TITLE
Move neutron logger keys to values

### DIFF
--- a/neutron/templates/etc/_neutron-logging.conf.tpl
+++ b/neutron/templates/etc/_neutron-logging.conf.tpl
@@ -1,7 +1,7 @@
 [loggers]
 #keys = root, neutron,neutron_lbaas, networkingaci,networkingdvs,networkingcisco,networkingarista,networking_f5_ml2,f5lbaasdriver,f5_openstack_agent
 
-keys = root, neutron,neutron_lbaas, networkingaci,f5lbaasdriver,f5_openstack_agent
+keys = {{.Values.loggers_keys}}
 
 [handlers]
 keys = stderr, stdout, null, sentry

--- a/neutron/values.yaml
+++ b/neutron/values.yaml
@@ -30,5 +30,7 @@ image_version_neutron_openvswitch_agent: DEFINED-IN-REGION-CHART
 image_version_neutron_vswitchdb: DEFINED-IN-REGION-CHART
 image_version_neutron_vswitchd: DEFINED-IN-REGION-CHART
 
+loggers_keys: 'root, neutron'
+
 postgres:
   name: neutron


### PR DESCRIPTION
This allows us to choose what to log on a regional level.
Ideally it would be derived dynamically from the enabled drivers.