### PR TITLE
Replace NodeSelectors with Taints and Tolerations

### DIFF
--- a/barbican/templates/deployment.yaml
+++ b/barbican/templates/deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         chart-version: {{.Chart.Version}}
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: barbican-api
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-barbican-m3:{{.Values.image_version_barbican_m3}}

--- a/cinder/templates/api-deployment.yaml
+++ b/cinder/templates/api-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: cinder-api
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: cinder-api
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-cinder-api-m3:{{.Values.image_version_cinder_api_m3}}

--- a/cinder/templates/scheduler-deployment.yaml
+++ b/cinder/templates/scheduler-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: cinder-scheduler
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: cinder-scheduler
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-cinder-scheduler:{{.Values.image_version_cinder_scheduler}}

--- a/designate/templates/api-deployment.yaml
+++ b/designate/templates/api-deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         chart-version: {{.Chart.Version}}
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: designate-api
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-designate-api-m3:{{.Values.image_version_designate_api_m3}}

--- a/designate/templates/central-deployment.yaml
+++ b/designate/templates/central-deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         chart-version: {{.Chart.Version}}
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: designate-central
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-designate-central-m3:{{.Values.image_version_designate_central_m3}}

--- a/designate/templates/mdns-deployment.yaml
+++ b/designate/templates/mdns-deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         chart-version: {{.Chart.Version}}
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: designate-mdns
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-designate-mdns-m3:{{.Values.image_version_designate_mdns_m3}}

--- a/designate/templates/poolmanager-deployment.yaml
+++ b/designate/templates/poolmanager-deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         chart-version: {{.Chart.Version}}
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: designate-poolmanager
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-designate-poolmanager-m3:{{.Values.image_version_designate_poolmanager_m3}}

--- a/europe-example-region/templates/nova/ironic-deployment.yaml
+++ b/europe-example-region/templates/nova/ironic-deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         pod.beta.kubernetes.io/hostname: nova-compute-ironic
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: nova-compute-ironic
           image: {{.Values.openstack.global.image_repository}}/{{.Values.openstack.global.image_namespace}}/ubuntu-source-nova-compute-m3:{{.Values.openstack.nova.image_version_nova_compute_m3}}

--- a/europe-example-region/templates/nova/kvm-deployment.yaml
+++ b/europe-example-region/templates/nova/kvm-deployment.yaml
@@ -18,28 +18,13 @@ spec:
       labels:
         name: nova-compute-minion1
       annotations:
-        scheduler.alpha.kubernetes.io/affinity: >
-            {
-            "nodeAffinity": {
-              "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
-                  {
-                    "matchExpressions": [
-                      {
-                        "key": "kubernetes.io/hostname",
-                        "operator": "In",
-                        "values": ["minion1.kube.your.domain"]
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-            }
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"hypervisor","effect":"NoSchedule"}]'
     spec:
       hostNetwork: true
       hostPID: true
       hostIPC: true
+      nodeSelector:
+        kubernetes.io/hostname: minion1.kube.your.domain
       containers:
         - name: nova-compute-minion1
           image: {{.Values.openstack.global.image_repository}}/{{.Values.openstack.global.image_namespace}}/ubuntu-source-nova-compute-m3:{{.Values.openstack.nova.image_version_nova_compute_m3}}

--- a/europe-example-region/templates/nova/vmware-deployment.yaml
+++ b/europe-example-region/templates/nova/vmware-deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         pod.beta.kubernetes.io/hostname:  nova-compute-vmware
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: nova-compute-vmware
           image: {{.Values.openstack.global.image_repository}}/{{.Values.openstack.global.image_namespace}}/ubuntu-source-nova-compute-m3:{{.Values.openstack.nova.image_version_nova_compute_m3}}

--- a/glance/templates/deployment.yaml
+++ b/glance/templates/deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: glance
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: glance-api
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-glance-api-m3:{{.Values.image_version_glance_api_m3}}

--- a/horizon/templates/deployment.yaml
+++ b/horizon/templates/deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         chart-version: {{.Chart.Version}}
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: horizon
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-horizon-m3:{{.Values.image_version_horizon_m3}}

--- a/ironic/templates/api-deployment.yaml
+++ b/ironic/templates/api-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: ironic-api
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: ironic-api
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-ironic-api:{{.Values.image_version_ironic_api}}

--- a/ironic/templates/conductor-deployment.yaml
+++ b/ironic/templates/conductor-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: ironic-conductor
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: ironic-conductor
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-ironic-conductor:{{.Values.image_version_ironic_conductor}}

--- a/ironic/templates/inspector-deployment.yaml
+++ b/ironic/templates/inspector-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: ironic-inspector
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: ironic-inspector
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-ironic-inspector:{{.Values.image_version_ironic_inspector}}

--- a/keystone/templates/deployment.yaml
+++ b/keystone/templates/deployment.yaml
@@ -27,8 +27,6 @@ spec:
       annotations:
         chart-version: {{.Chart.Version}}
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: keystone
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-keystone-m3:{{.Values.image_version_keystone_m3}}

--- a/manila/templates/api-deployment.yaml
+++ b/manila/templates/api-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: manila-api
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: manila-api
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-manila-api-m3:{{.Values.image_version_manila_api_m3}}

--- a/manila/templates/scheduler-deployment.yaml
+++ b/manila/templates/scheduler-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: manila-scheduler
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: manila-scheduler
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-manila-scheduler-m3:{{.Values.image_version_manila_scheduler_m3}}

--- a/mariadb/templates/deployment.yaml
+++ b/mariadb/templates/deployment.yaml
@@ -19,8 +19,6 @@ spec:
         app: {{.Values.name}}-mariadb
 
     spec:
-      nodeSelector:
-        zone: farm
       containers:
       - name: mariadb
         image: {{.Values.image}}

--- a/memcached/templates/deployment.yaml
+++ b/memcached/templates/deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: memcached
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: memcached
           image: memcached

--- a/neutron/templates/aci-agent-deployment.yaml
+++ b/neutron/templates/aci-agent-deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         pod.beta.kubernetes.io/hostname:  aci-agent-pet
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: neutron-aci-agent
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-neutron-server-m3:{{.Values.image_version_neutron_server_m3}}

--- a/neutron/templates/asr-deployment.yaml
+++ b/neutron/templates/asr-deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         pod.beta.kubernetes.io/hostname:  asr-pet
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: neutron-cisco-asr
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-neutron-server-m3:{{.Values.image_version_neutron_server_m3}}

--- a/neutron/templates/f5-deployment.yaml
+++ b/neutron/templates/f5-deployment.yaml
@@ -24,8 +24,6 @@ spec:
       annotations:
         pod.beta.kubernetes.io/hostname:  f5-pet
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: neutron-f5-agent
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-neutron-server-m3:{{.Values.image_version_neutron_server_m3}}

--- a/neutron/templates/server-deployment.yaml
+++ b/neutron/templates/server-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: neutron-server
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: neutron-server
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-neutron-server-m3:{{.Values.image_version_neutron_server_m3}}

--- a/nova/templates/api-deployment.yaml
+++ b/nova/templates/api-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: nova-api
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: nova-api
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-nova-api-m3:{{.Values.image_version_nova_api_m3}}

--- a/nova/templates/conductor-deployment.yaml
+++ b/nova/templates/conductor-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: nova-conductor
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: nova-conductor
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-nova-conductor:{{.Values.image_version_nova_conductor}}

--- a/nova/templates/console-deployment.yaml
+++ b/nova/templates/console-deployment.yaml
@@ -23,8 +23,6 @@ spec:
         name: nova-console
 
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: nova-consoleauth
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-nova-consoleauth:{{.Values.image_version_nova_consoleauth}}

--- a/nova/templates/scheduler-deployment.yaml
+++ b/nova/templates/scheduler-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         name: nova-scheduler
     spec:
-      nodeSelector:
-        zone: farm
       containers:
         - name: nova-scheduler
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-nova-scheduler:{{.Values.image_version_nova_scheduler}}

--- a/postgres/templates/deployment.yaml
+++ b/postgres/templates/deployment.yaml
@@ -21,8 +21,6 @@ spec:
         name: postgres-{{.Values.name}}
     spec:
       hostPID: false
-      nodeSelector:
-        zone: farm
       volumes:
         - name: postgres-persistent-storage
           persistentVolumeClaim:

--- a/rabbitmq/templates/deployment.yaml
+++ b/rabbitmq/templates/deployment.yaml
@@ -19,8 +19,6 @@ spec:
       labels:
         name: rabbitmq
     spec:
-      nodeSelector:
-        zone: farm
       volumes:
         - name: rabbitmq-persistent-storage
           persistentVolumeClaim:


### PR DESCRIPTION
We have two use cases for exclusive nodes:

  * Hypervisor
  * Network

Only specific pods should be scheduled to these nodes. We will achieve this by
tainting the nodes:

```
kubectl taint network0 species=network:NoSchedule
kubectl taint network1 species=network:NoSchedule
kubectl taint minion1  species=hypervisor:NoSchedule
```

Now nothing can be scheduled there. Pods that should be able to go to this need to
have a toleration added.

```
annotations:
  scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"hypervisor"}]'
```

These pods could still go to any node though. We need to confine KVM pods to
the hyperivsors and neutron agents to their dedicated network nodes. We do this
by labeling the nodes:

```
kubectl label network0 species=network
kubectl label minion1  species=hypervisor
```

Then add selectors to the pods:

```
spec:
  nodeSelector:
    species: hypervisor
    kubernetes.io/hostname: minion1
```

To lock pods onto a particular node we do:

```
spec:
  nodeSelector:
    kubernetes.io/hostname: minion1
```