### PR TITLE
Move DB migration from independent scripts into jobs

### DIFF
--- a/barbican/templates/deployment.yaml
+++ b/barbican/templates/deployment.yaml
@@ -31,15 +31,20 @@ spec:
           securityContext:
             privileged: true
           command:
-            - bash
-          args:
-            - /container.init/barbican-api-start
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: {{.Values.global.barbican_api_port_internal}}
-#            initialDelaySeconds: 15
-#            timeoutSeconds: 5
+            - /usr/local/bin/kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "bash /container.init/barbican-api-start"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-barbican,rabbitmq"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{.Values.global.barbican_api_port_internal}}
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
           ports:
             - name: barbican-api
               containerPort: {{.Values.global.barbican_api_port_internal}}

--- a/cinder/bin/db-migrate
+++ b/cinder/bin/db-migrate
@@ -4,19 +4,12 @@ set -e
 
 . /container.init/common.sh
 
+
+
 function process_config {
     cp /cinder-etc/cinder.conf /etc/cinder/cinder.conf
     cp /cinder-etc/logging.conf /etc/cinder/logging.conf
 }
 
-
-function start_application {
-    exec /var/lib/kolla/venv/bin/cinder-api
-
-}
-
-
 process_config
-start_application
-
-
+cinder-manage db sync

--- a/cinder/templates/api-deployment.yaml
+++ b/cinder/templates/api-deployment.yaml
@@ -30,9 +30,17 @@ spec:
             privileged: true
           command:
             - bash
-          args:
-            - /container.init/cinder-api-start
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
           env:
+            - name: COMMAND
+              value: "bash /container.init/cinder-api-start"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_JOBS
+              value: "cinder-migration"
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-cinder,rabbitmq"
             - name: DEBUG_CONTAINER
               value: "false"
             - name: STATSD_HOST

--- a/cinder/templates/bin-configmap.yaml
+++ b/cinder/templates/bin-configmap.yaml
@@ -14,6 +14,9 @@ data:
 {{ .Files.Get "bin/cinder-scheduler-start" | indent 4 }}
   cinder-volume-start: |
 {{ .Files.Get "bin/cinder-volume-start" | indent 4 }}
+  db-migrate: |
+{{ .Files.Get "bin/db-migrate" | indent 4 }}
+
   common.sh: |
 {{ include "common.sh" .| indent 4 }}
 

--- a/cinder/templates/migration-job.yaml
+++ b/cinder/templates/migration-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cinder-migration
+  labels:
+    system: openstack
+    type: configuration
+    component: cinder
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: cinder-migration
+          image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-cinder-api-m3:{{.Values.image_version_cinder_api_m3}}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "bash /container.init/db-migrate"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-cinder"
+          volumeMounts:
+            - mountPath: /cinder-etc
+              name: cinder-etc
+            - mountPath: /container.init
+              name: container-init
+      volumes:
+        - name: cinder-etc
+          configMap:
+            name: cinder-etc
+        - name: container-init
+          configMap:
+            name: cinder-bin

--- a/glance/bin/db-migrate
+++ b/glance/bin/db-migrate
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+. /container.init/common.sh
+
+
+
+function process_config {
+    cp /glance-etc/glance-api.conf  /etc/glance/glance-api.conf
+    cp /glance-etc/logging.conf /etc/glance/logging.conf
+}
+
+process_config
+glance-manage db_sync

--- a/glance/bin/glance-api-start
+++ b/glance/bin/glance-api-start
@@ -14,11 +14,6 @@ function process_config {
     cp /glance-etc/policy.json /etc/glance/policy.json
 }
 
-function bootstrap_db {
-    glance-manage db_sync
-}
-
-
 function _start_application {
     #chown -R glance: /glance_store
     exec  /var/lib/kolla/venv/bin/glance-api
@@ -26,5 +21,4 @@ function _start_application {
 
 
 process_config
-#bootstrap_db
 start_application

--- a/glance/templates/bin-configmap.yaml
+++ b/glance/templates/bin-configmap.yaml
@@ -12,6 +12,8 @@ data:
 {{ .Files.Get "bin/glance-api-start" | indent 4 }}
   glance-registry-start: |
 {{ .Files.Get "bin/glance-registry-start" | indent 4 }}
+  db-migrate: |
+{{ .Files.Get "bin/db-migrate" | indent 4 }}
   common.sh: |
 {{ include "common.sh" .| indent 4 }}
 

--- a/glance/templates/deployment.yaml
+++ b/glance/templates/deployment.yaml
@@ -26,17 +26,23 @@ spec:
         - name: glance-api
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-glance-api-m3:{{.Values.image_version_glance_api_m3}}
           imagePullPolicy: IfNotPresent
-          command:
-            - bash
-          args:
-            - /container.init/glance-api-start
           livenessProbe:
             httpGet:
               path: /
               port: {{.Values.global.glance_api_port_internal}}
             initialDelaySeconds: 15
             timeoutSeconds: 5
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
           env:
+            - name: COMMAND
+              value: "bash /container.init/glance-api-start"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_JOBS
+              value: "glance-migration"
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-glance,rabbitmq"
             - name: DEBUG_CONTAINER
               value: "false"
             - name: STATSD_HOST

--- a/glance/templates/migration-job.yaml
+++ b/glance/templates/migration-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glance-migration
+  labels:
+    system: openstack
+    type: configuration
+    component: glance
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: glance-migration
+          image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-glance-api-m3:{{.Values.image_version_glance_api_m3}}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "bash /container.init/db-migrate"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-glance"
+          volumeMounts:
+            - mountPath: /glance-etc
+              name: glance-etc
+            - mountPath: /container.init
+              name: container-init
+      volumes:
+        - name: glance-etc
+          configMap:
+            name: glance-etc
+        - name: container-init
+          configMap:
+            name: glance-bin

--- a/ironic/bin/db-migrate
+++ b/ironic/bin/db-migrate
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+. /container.init/common.sh
+
+
+
+function process_config {
+    cp /ironic-etc/ironic.conf  /etc/ironic/ironic.conf
+}
+
+process_config
+ironic-dbsync --config-file /etc/ironic/ironic.conf create_schema

--- a/ironic/bin/ironic-api-start
+++ b/ironic/bin/ironic-api-start
@@ -10,12 +10,6 @@ function process_config {
     cp /ironic-etc/ironic.conf  /etc/ironic/ironic.conf
 }
 
-function bootstrap_db {
-
-    ironic-dbsync --config-file /etc/ironic/ironic.conf create_schema
-}
-
-
 function start_application {
 
    exec /var/lib/kolla/venv/bin/ironic-api
@@ -24,7 +18,6 @@ function start_application {
 
 
 process_config
-#bootstrap_db
 start_application
 
 

--- a/ironic/bin/ironic-inspector-start
+++ b/ironic/bin/ironic-inspector-start
@@ -17,7 +17,7 @@ function _start_application {
 }
 
 
-process_config
+#process_config
 start_application
 
 

--- a/ironic/templates/api-deployment.yaml
+++ b/ironic/templates/api-deployment.yaml
@@ -29,9 +29,16 @@ spec:
           securityContext:
             privileged: true
           command:
-            - bash
-          args:
-            - /container.init/ironic-api-start
+            - /usr/local/bin/kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "bash /container.init/ironic-api-start"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_JOBS
+              value: "ironic-migration"
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-ironic,rabbitmq"
           livenessProbe:
             httpGet:
               path: /

--- a/ironic/templates/bin-configmap.yaml
+++ b/ironic/templates/bin-configmap.yaml
@@ -16,6 +16,8 @@ data:
 {{ .Files.Get "bin/ironic-inspector-start" | indent 4 }}
   ironic-pxe-start: |
 {{ .Files.Get "bin/ironic-pxe-start" | indent 4 }}
+  db-migrate: |
+{{ .Files.Get "bin/db-migrate" | indent 4 }}
   common.sh: |
 {{ include "common.sh" . | indent 4 }}
 

--- a/ironic/templates/migration-job.yaml
+++ b/ironic/templates/migration-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ironic-migration
+  labels:
+    system: openstack
+    type: configuration
+    component: ironic
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: ironic-migration
+          image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-ironic-api:{{.Values.image_version_ironic_api}}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "bash /container.init/db-migrate"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-ironic"
+          volumeMounts:
+            - mountPath: /ironic-etc
+              name: ironic-etc
+            - mountPath: /container.init
+              name: container-init
+      volumes:
+        - name: ironic-etc
+          configMap:
+            name: ironic-etc
+        - name: container-init
+          configMap:
+            name: ironic-bin

--- a/ironic/templates/pxe-deployment.yaml
+++ b/ironic/templates/pxe-deployment.yaml
@@ -21,6 +21,8 @@ spec:
     metadata:
       labels:
         name: ironic-pxe
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"none"}]'
     spec:
       nodeSelector:
         kubernetes.io/hostname: {{.Values.global.ironic_pxe_endpoint_host_public}}

--- a/keystone/templates/bin-configmap.yaml
+++ b/keystone/templates/bin-configmap.yaml
@@ -16,3 +16,5 @@ data:
 {{ tuple "bin/_keystone-seed.tpl" . | include "template" | indent 4 }}
   keystone-start: |
 {{ tuple "bin/_keystone-start.tpl" . | include "template" | indent 4 }}
+  db-migrate: |
+{{ tuple "bin/_db-migrate.tpl" . | include "template" | indent 4 }}

--- a/keystone/templates/bin/_db-migrate.tpl
+++ b/keystone/templates/bin/_db-migrate.tpl
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+. /container.init/common.sh
+
+
+
+function process_config {
+    cp /keystone-etc/keystone.conf  /etc/keystone/keystone.conf
+    cp /keystone-etc/policyv3.json  /etc/keystone/policy.json
+
+}
+
+process_config
+keystone-manage db_sync

--- a/keystone/templates/deployment.yaml
+++ b/keystone/templates/deployment.yaml
@@ -31,17 +31,23 @@ spec:
         - name: keystone
           image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-keystone-m3:{{.Values.image_version_keystone_m3}}
           imagePullPolicy: IfNotPresent
-          command:
-            - bash
-          args:
-            - /container.init/keystone-start
           livenessProbe:
             httpGet:
               path: /v3
               port: 5000
             initialDelaySeconds: 15
             timeoutSeconds: 15
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
           env:
+            - name: COMMAND
+              value: "bash /container.init/keystone-start"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_JOBS
+              value: "keystone-migration"
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-keystone,rabbitmq"
             - name: DEBUG_CONTAINER
               value: "false"
             - name: SENTRY_DSN

--- a/keystone/templates/migration-job.yaml
+++ b/keystone/templates/migration-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: keystone-migration
+  labels:
+    system: openstack
+    type: configuration
+    component: keystone
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: keystone-migration
+          image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-keystone-m3:{{.Values.image_version_keystone_m3}}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "bash /container.init/db-migrate"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-ironic"
+          volumeMounts:
+            - mountPath: /keystone-etc
+              name: keystone-etc
+            - mountPath: /container.init
+              name: container-init
+      volumes:
+        - name: keystone-etc
+          configMap:
+            name: keystone-etc
+        - name: container-init
+          configMap:
+            name: keystone-bin

--- a/manila/bin/db-migrate
+++ b/manila/bin/db-migrate
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+. /container.init/common.sh
+
+
+
+function process_config {
+    cp /manila-etc/manila.conf  /etc/manila/manila.conf
+    if [[ ! -d /var/log/manila ]] ; then
+        mkdir /var/log/manila
+    fi
+}
+
+process_config
+manila-manage db sync

--- a/manila/templates/api-deployment.yaml
+++ b/manila/templates/api-deployment.yaml
@@ -29,10 +29,16 @@ spec:
           securityContext:
             privileged: true
           command:
-            - bash
-          args:
-            - /container.init/manila-api-start
+            - /usr/local/bin/kubernetes-entrypoint
           env:
+            - name: COMMAND
+              value: "bash /container.init/manila-api-start"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_JOBS
+              value: "manila-migration"
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-manila,rabbitmq"
             - name: DEBUG_CONTAINER
               value: "false"
           livenessProbe:

--- a/manila/templates/bin-configmap.yaml
+++ b/manila/templates/bin-configmap.yaml
@@ -14,6 +14,8 @@ data:
 {{ .Files.Get "bin/manila-scheduler-start" | indent 4 }}
   manila-share-start: |
 {{ .Files.Get "bin/manila-share-start" | indent 4 }}
+  db-migrate: |
+{{ .Files.Get "bin/db-migrate" | indent 4 }}
   common.sh: |
 {{ include "common.sh" .| indent 4 }}
 

--- a/manila/templates/migration-job.yaml
+++ b/manila/templates/migration-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: manila-migration
+  labels:
+    system: openstack
+    type: configuration
+    component: manila
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: manila-migration
+          image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-manila-api-m3:{{.Values.image_version_manila_api_m3}}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "bash /container.init/db-migrate"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-manila"
+          volumeMounts:
+            - mountPath: /manila-etc
+              name: manila-etc
+            - mountPath: /container.init
+              name: container-init
+      volumes:
+        - name: manila-etc
+          configMap:
+            name: manila-etc
+        - name: container-init
+          configMap:
+            name: manila-bin

--- a/neutron/templates/bin-configmap.yaml
+++ b/neutron/templates/bin-configmap.yaml
@@ -21,6 +21,8 @@ data:
 {{ tuple "bin/_neutron-ovs-start.tpl" . | include "template" | indent 4 }}
   neutron-server-start: |
 {{ tuple "bin/_neutron-server-start.tpl" . | include "template" | indent 4 }}
+  db-migrate: |
+{{ tuple "bin/_db-migrate.tpl" . | include "template" | indent 4 }}
   common.sh: |
 {{ include "common.sh" .| indent 4 }}
 

--- a/neutron/templates/bin/_db-migrate.tpl
+++ b/neutron/templates/bin/_db-migrate.tpl
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+. /container.init/common.sh
+
+
+
+function process_config {
+    cp /neutron-etc/neutron.conf  /etc/neutron/neutron.conf
+    cp /neutron-etc/logging.conf  /etc/neutron/logging.conf
+    cp /neutron-etc/neutron-lbaas.conf /etc/neutron/neutron_lbaas.conf
+    cp /neutron-etc/ml2-conf.ini  /etc/neutron/plugins/ml2/ml2_conf.ini
+
+
+}
+
+process_config
+neutron-db-manage upgrade head
+neutron-db-manage --subproject neutron-lbaas upgrade head

--- a/neutron/templates/bin/_neutron-server-start.tpl
+++ b/neutron/templates/bin/_neutron-server-start.tpl
@@ -38,18 +38,9 @@ function process_config {
     cp /neutron-etc-vendor/cisco-router-plugin.ini   /etc/neutron/plugins/cisco/cisco_router_plugin.ini
 }
 
-function bootstrap_db {
-    neutron-db-manage --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2_conf.ini upgrade head
-}
-
-
 function _start_application {
     /var/lib/kolla/venv/bin/neutron-server --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/neutron_lbaas.conf --config-file /etc/neutron/plugins/ml2/ml2_conf.ini  --config-file /etc/neutron/plugins/ml2/ml2_conf_f5.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-aci.ini --config-file /etc/neutron/plugins/ml2/ml2_conf_asr.ini --config-file /etc/neutron/plugins/ml2/ml2_conf_manila.ini --config-file /etc/neutron/plugins/ml2/ml2_conf_arista.ini --config-file /etc/neutron/plugins/cisco/cisco_device_manager_plugin.ini --config-file /etc/neutron/plugins/cisco/cisco_router_plugin.ini
 }
 
-
-
-
 process_config
-bootstrap_db
 start_application

--- a/neutron/templates/migration-job.yaml
+++ b/neutron/templates/migration-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: neutron-migration
+  labels:
+    system: openstack
+    type: configuration
+    component: neutron
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: neutron-migration
+          image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-neutron-server-m3:{{.Values.image_version_neutron_server_m3}}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "bash /container.init/db-migrate"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-neutron"
+          volumeMounts:
+            - mountPath: /neutron-etc
+              name: neutron-etc
+            - mountPath: /container.init
+              name: container-init
+      volumes:
+        - name: neutron-etc
+          configMap:
+            name: neutron-etc
+        - name: container-init
+          configMap:
+            name: neutron-bin

--- a/neutron/templates/server-deployment.yaml
+++ b/neutron/templates/server-deployment.yaml
@@ -28,17 +28,23 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
-          command:
-            - bash
-          args:
-            - /container.init/neutron-server-start
           livenessProbe:
             httpGet:
               path: /
               port: {{.Values.global.neutron_api_port_internal}}
             initialDelaySeconds: 60
             timeoutSeconds: 5
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
           env:
+            - name: COMMAND
+              value: "bash /container.init/neutron-server-start"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_JOBS
+              value: "neutron-migration"
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-neutron,rabbitmq"
             - name: DEBUG_CONTAINER
               value: "false"
             - name: STATSD_HOST

--- a/nova/bin/db-migrate
+++ b/nova/bin/db-migrate
@@ -4,19 +4,14 @@ set -e
 
 . /container.init/common.sh
 
+
+
 function process_config {
     cp /nova-etc/nova.conf  /etc/nova/nova.conf
     cp /nova-etc/logging.conf  /etc/nova/logging.conf
-    cp /nova-etc/policy.json  /etc/nova/policy.json
 }
-
-
-
-
-function _start_application {
-    exec  /var/lib/kolla/venv/bin/nova-api
-}
-
 
 process_config
-start_application
+nova-manage db sync
+nova-manage api_db sync
+#nova-manage db online_data_migrations

--- a/nova/templates/api-deployment.yaml
+++ b/nova/templates/api-deployment.yaml
@@ -29,10 +29,16 @@ spec:
           securityContext:
             privileged: true
           command:
-            - bash
-          args:
-            - /container.init/nova-api-start
+            - /usr/local/bin/kubernetes-entrypoint
           env:
+            - name: COMMAND
+              value: "bash /container.init/nova-api-start"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_JOBS
+              value: "nova-migration"
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-nova,rabbitmq"
             - name: DEBUG_CONTAINER
               value: "false"
             - name: STATSD_HOST

--- a/nova/templates/bin-configmap.yaml
+++ b/nova/templates/bin-configmap.yaml
@@ -26,6 +26,8 @@ data:
 {{ .Files.Get "bin/nova-spicehtml5proxy-start" | indent 4 }}
   nova-virtlog-start: |
 {{ .Files.Get "bin/nova-virtlog-start" | indent 4 }}
+  db-migrate: |
+{{ .Files.Get "bin/db-migrate" | indent 4 }}
   common.sh: |
 {{ include "common.sh" .| indent 4 }}
 

--- a/nova/templates/migration-job.yaml
+++ b/nova/templates/migration-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nova-migration
+  labels:
+    system: openstack
+    type: configuration
+    component: nova
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: nova-migration
+          image: {{.Values.global.image_repository}}/{{.Values.global.image_namespace}}/ubuntu-source-nova-api-m3:{{.Values.image_version_nova_api_m3}}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "bash /container.init/db-migrate"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_SERVICE
+              value: "postgres-nova"
+          volumeMounts:
+            - mountPath: /nova-etc
+              name: nova-etc
+            - mountPath: /container.init
+              name: container-init
+      volumes:
+        - name: nova-etc
+          configMap:
+            name: nova-etc
+        - name: container-init
+          configMap:
+            name: nova-bin


### PR DESCRIPTION
We currently manage DB migrations with separate Bash scripts run manually on initial deployment. This is an initial start to deploy them as Jobs as part of regular Helm release.  

We've adopted the [stackenetes entrypoint](https://github.com/stackanetes/kubernetes-entrypoint) wrapper to help with dependency management. It requires images to be built to include the binary @ /usr/local/bin/kubernetes-entrypoint