### PR TITLE
[neutron_vendor] patch F5 agent to always assume common

### DIFF
--- a/neutron_vendor/patches/f5/service_builder.diff
+++ b/neutron_vendor/patches/f5/service_builder.diff
@@ -1,5 +1,5 @@
---- neutron/patches/f5/service_builder.orig.py	2016-11-09 14:37:09.000000000 +0000
-+++ neutron/patches/f5/service_builder.patch.py	2016-11-09 14:37:09.000000000 +0000
+--- service_builder.orig.py	2016-11-11 15:07:51.000000000 +0100
++++ service_builder.patch.py	2017-01-10 10:31:35.000000000 +0100
 @@ -94,11 +94,10 @@
              segment_data = self.disconnected_service.get_network_segment(
                  context, agent_config, network)
@@ -16,3 +16,49 @@
              network_map[network_id] = network
  
              # Check if the tenant can create a loadbalancer on the network.
+@@ -367,25 +366,26 @@
+ 
+     @log_helpers.log_method_call
+     def _is_common_network(self, network, agent):
+-        common_external_networks = False
+-        common_networks = {}
+-
+-        if agent and "configurations" in agent:
+-            agent_configs = self.deserialize_agent_configurations(
+-                agent['configurations'])
+-
+-            if 'common_networks' in agent_configs:
+-                common_networks = agent_configs['common_networks']
+-
+-            if 'f5_common_external_networks' in agent_configs:
+-                common_external_networks = (
+-                    agent_configs['f5_common_external_networks'])
+-
+-        return (network['shared'] or
+-                (network['id'] in common_networks) or
+-                ('router:external' in network and
+-                 network['router:external'] and
+-                 common_external_networks))
++        # common_external_networks = False
++        # common_networks = {}
++        #
++        # if agent and "configurations" in agent:
++        #     agent_configs = self.deserialize_agent_configurations(
++        #         agent['configurations'])
++        #
++        #     if 'common_networks' in agent_configs:
++        #         common_networks = agent_configs['common_networks']
++        #
++        #     if 'f5_common_external_networks' in agent_configs:
++        #         common_external_networks = (
++        #             agent_configs['f5_common_external_networks'])
++        #
++        # return (network['shared'] or
++        #         (network['id'] in common_networks) or
++        #         ('router:external' in network and
++        #          network['router:external'] and
++        #          common_external_networks))
++        return True
+ 
+     def _valid_tenant_ids(self, network, lb_tenant_id, agent):
+         if (network['tenant_id'] == lb_tenant_id):

--- a/neutron_vendor/patches/f5/service_builder.patch.py
+++ b/neutron_vendor/patches/f5/service_builder.patch.py
@@ -366,25 +366,26 @@ class LBaaSv2ServiceBuilder(object):
 
     @log_helpers.log_method_call
     def _is_common_network(self, network, agent):
-        common_external_networks = False
-        common_networks = {}
-
-        if agent and "configurations" in agent:
-            agent_configs = self.deserialize_agent_configurations(
-                agent['configurations'])
-
-            if 'common_networks' in agent_configs:
-                common_networks = agent_configs['common_networks']
-
-            if 'f5_common_external_networks' in agent_configs:
-                common_external_networks = (
-                    agent_configs['f5_common_external_networks'])
-
-        return (network['shared'] or
-                (network['id'] in common_networks) or
-                ('router:external' in network and
-                 network['router:external'] and
-                 common_external_networks))
+        # common_external_networks = False
+        # common_networks = {}
+        #
+        # if agent and "configurations" in agent:
+        #     agent_configs = self.deserialize_agent_configurations(
+        #         agent['configurations'])
+        #
+        #     if 'common_networks' in agent_configs:
+        #         common_networks = agent_configs['common_networks']
+        #
+        #     if 'f5_common_external_networks' in agent_configs:
+        #         common_external_networks = (
+        #             agent_configs['f5_common_external_networks'])
+        #
+        # return (network['shared'] or
+        #         (network['id'] in common_networks) or
+        #         ('router:external' in network and
+        #          network['router:external'] and
+        #          common_external_networks))
+        return True
 
     def _valid_tenant_ids(self, network, lb_tenant_id, agent):
         if (network['tenant_id'] == lb_tenant_id):


### PR DESCRIPTION
another instance of https://github.com/sapcc/openstack-helm/commit/378fca4727058c6ce6ee787eb3741aec4b64a02e

workaround for rbac shared networks: they are not shown as legacy shared (at least for the cloud_network_admin), but don't reside in the same project like the lbaas objects - so it needs to go into the common partition

@fwiesel : does this look ok to you?

@abattye FYI