### PR TITLE
Adding SENTRY_DSN env to 3 manila service deployment files.

### DIFF
--- a/manila/templates/api-deployment.yaml
+++ b/manila/templates/api-deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: "postgres-manila,rabbitmq"
             - name: DEBUG_CONTAINER
               value: "false"
+            - name: SENTRY_DSN
+              value: {{.Values.sentry_dsn | quote}}
           livenessProbe:
             httpGet:
               path: /

--- a/manila/templates/availabilty-zone/_netapp-deployment.yaml.tpl
+++ b/manila/templates/availabilty-zone/_netapp-deployment.yaml.tpl
@@ -38,6 +38,8 @@ spec:
           env:
             - name: DEBUG_CONTAINER
               value: "false"
+            - name: SENTRY_DSN
+              value: {{.Values.sentry_dsn | quote}}
           volumeMounts:
             - mountPath: /manila-etc
               name: manila-etc

--- a/manila/templates/availabilty-zone/_scheduler-deployment.yaml.tpl
+++ b/manila/templates/availabilty-zone/_scheduler-deployment.yaml.tpl
@@ -41,6 +41,8 @@ spec:
               value: "manila-api,rabbitmq"
             - name: DEBUG_CONTAINER
               value: "false"
+            - name: SENTRY_DSN
+              value: {{.Values.sentry_dsn | quote}}
           volumeMounts:
             - mountPath: /manila-etc
               name: manila-etc


### PR DESCRIPTION
@Carthaca 

adding the below entry to the 3 respective manila deployment files.

- name: SENTRY_DSN
   value: {{.Values.sentry_dsn | quote}}