### PR TITLE
Configurable swift_store object size options in glance. 

### DIFF
--- a/glance/templates/etc/_glance-api.conf.tpl
+++ b/glance/templates/etc/_glance-api.conf.tpl
@@ -58,5 +58,8 @@ swift_store_config_file=/etc/glance/swift-store.conf
 
 swift_store_use_trusts=True
 
+swift_store_large_object_size = {{ .Values.swift_store_large_object_size | default .Values.global.swift_store_large_object_size | default 5120 }}
+swift_store_large_object_chunk_size = {{ .Values.swift_store_large_object_chunk_size | default .Values.global.swift_store_large_object_chunk_size | default 200 }}
+
 [oslo_messaging_notifications]
 driver = noop


### PR DESCRIPTION
We have issue snapshoting larger images and need to tune those values in glance for investigation.

swift_store_large_object_size, swift_store_large_object_chunk_size