### PR TITLE
increase initial-delay for liveness check

### DIFF
--- a/postgres/templates/deployment.yaml
+++ b/postgres/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
               - "{{.Values.port_private}}"
               - -U
               - postgres
-            initialDelaySeconds: 20
+            initialDelaySeconds: 60
             timeoutSeconds: 5
           env:
             - name: PGDATA


### PR DESCRIPTION
I just found a postgres crash-looping for already more than 450 times... 😄 

The problem was an unclean shutdown:

```
waiting for server to start....LOG:  could not create IPv6 socket: Address family not supported by protocol
.FATAL:  the database system is starting up
.FATAL:  the database system is starting up
.FATAL:  the database system is starting up
.FATAL:  the database system is starting up
.FATAL:  the database system is starting up
.FATAL:  the database system is starting up
.FATAL:  the database system is starting up
.FATAL:  the database system is starting up
.LOG:  database system was not properly shut down; automatic recovery in progress
LOG:  record with zero length at E/61FD00E8
LOG:  redo is not required
```

This recovery took like 1 minute. The livenessprobe starts probing 20s after pod startup. And after 5 failed attempts it killed the pod. Kicking it into a death spiral.

I manually edited the deployment and set the `initialDelay` to 60 seconds. It came back.

This patch changes the delay to 60s.  For bigger databases the recovery takes longer. Maybe even 5min initial delay would be reasonable. I'm not sure why the default has been lowered here, but it needs to be increased to at least 1 minute. Possibly more.