### PR TITLE
Select components with tags and conditional requirements

### DIFF
--- a/europe-example-region/values.yaml
+++ b/europe-example-region/values.yaml
@@ -6,6 +6,8 @@
 # This is a YAML-formatted file.
 # Declare name/value pairs to be passed into your templates.
 # name: value
+tags:
+  ironic: true
 
 global:
   region: eu

--- a/openstack/requirements.yaml
+++ b/openstack/requirements.yaml
@@ -8,36 +8,58 @@ dependencies:
   - name: keystone
     repository: http://localhost:8879/charts
     version: 0.1.0
+    tags:
+        - keystone
   - name: glance
     repository: http://localhost:8879/charts
     version: 0.1.1
+    tags:
+        - glance
   - name: ironic
     repository: http://localhost:8879/charts
     version: 0.1.0
+    tags:
+        - ironic
   - name: nova
     repository: http://localhost:8879/charts
     version: 0.1.1
+    tags:
+        - nova
   - name: barbican
     repository: http://localhost:8879/charts
     version: 0.1.0
+    tags:
+        - barbican
   - name: cinder
     repository: http://localhost:8879/charts
     version: 0.1.1
+    tags:
+        - cinder
   - name: manila
     repository: http://localhost:8879/charts
     version: 0.1.0
+    tags:
+        - manila
   - name: horizon
     repository: http://localhost:8879/charts
     version: 0.1.0
+    tags:
+        - horizon
   - name: neutron
     repository: http://localhost:8879/charts
     version: 0.1.1
+    tags:
+        - neutron
   - name: neutron_vendor
     repository: http://localhost:8879/charts
     version: 0.1.0
+    tags:
+        - neutron
   - name: designate
     repository: http://localhost:8879/charts
     version: 0.1.1
+    tags:
+        - designate
   - name: healthchecks
     repository: http://localhost:8879/charts
     version: 0.1.0

--- a/openstack/values.yaml
+++ b/openstack/values.yaml
@@ -2,6 +2,18 @@
 # This is a YAML-formatted file.
 # Declare name/value pairs to be passed into your templates.
 # name: value
+tags:
+  barbican: true
+  keystone: true
+  glance: true
+  nova: true
+  barbican: true
+  cinder: true
+  manila: true
+  horizon: true
+  neutron: true
+  designate: true
+  ironic: true
 
 global:
   os_release: mitaka


### PR DESCRIPTION
Currently, all components except ironic are marked as required by default

By setting
```
tags:
  manila: false
  ironic: true
```

you could install ironic, but not install manila.

This should enable us to migrate away from a monolithic deployment to a component-wise one.
