### PR TITLE
increase replica count for api servers

### DIFF
--- a/barbican/templates/etc/_barbican.conf.tpl
+++ b/barbican/templates/etc/_barbican.conf.tpl
@@ -48,4 +48,4 @@ rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | defa
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
 max_pool_size = {{ .Values.max_pool_size | default .Values.global.max_pool_size | default 5 }}
-max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 10 }}
+max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 0 }}

--- a/barbican/values.yaml
+++ b/barbican/values.yaml
@@ -20,7 +20,7 @@ postgres:
   name: barbican
 
 replicas:
-    api: 1
+    api: 2
 upgrades:
     revision_history: 5
     pod_replacement_strategy: RollingUpdate

--- a/cinder/templates/api-deployment.yaml
+++ b/cinder/templates/api-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     type: api
     component: cinder
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate

--- a/cinder/templates/etc/_cinder.conf.tpl
+++ b/cinder/templates/etc/_cinder.conf.tpl
@@ -26,7 +26,7 @@ rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | defa
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
 max_pool_size = {{ .Values.max_pool_size | default .Values.global.max_pool_size | default 5 }}
-max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 10 }}
+max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 0 }}
 
 # all default quotas are 0 to enforce usage of the Resource Management tool in Elektra
 quota_volumes = 0

--- a/designate/templates/api-deployment.yaml
+++ b/designate/templates/api-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     type: api
     component: designate
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate

--- a/designate/templates/etc/_designate.conf.tpl
+++ b/designate/templates/etc/_designate.conf.tpl
@@ -53,7 +53,7 @@ rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | defa
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
 max_pool_size = {{ .Values.max_pool_size | default .Values.global.max_pool_size | default 5 }}
-max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 10 }}
+max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 0 }}
 
 {{include "oslo_messaging_rabbit" .}}
 

--- a/glance/templates/deployment.yaml
+++ b/glance/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     type: api
     component: glance
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate

--- a/glance/templates/etc/_glance-api.conf.tpl
+++ b/glance/templates/etc/_glance-api.conf.tpl
@@ -40,7 +40,7 @@ max_pool_size = {{ .Values.max_pool_size | default .Values.global.max_pool_size 
 
 # If set, use this value for max_overflow with SQLAlchemy. (integer
 # value)
-max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 10 }}
+max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 0 }}
 
 # The value for the socket option TCP_KEEPIDLE.  This is the time in
 # seconds that the connection must be idle before TCP starts sending

--- a/ironic/templates/api-deployment.yaml
+++ b/ironic/templates/api-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     type: api
     component: ironic
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate

--- a/manila/templates/api-deployment.yaml
+++ b/manila/templates/api-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     type: api
     component: manila
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate

--- a/manila/templates/etc/_manila.conf.tpl
+++ b/manila/templates/etc/_manila.conf.tpl
@@ -28,7 +28,7 @@ rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | defa
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
 max_pool_size = {{ .Values.max_pool_size | default .Values.global.max_pool_size | default 5 }}
-max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 10 }}
+max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 0 }}
 
 # all default quotas are 0 to enforce usage of the Resource Management tool in Elektra
 quota_shares = 0

--- a/nova/templates/api-deployment.yaml
+++ b/nova/templates/api-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     type: api
     component: nova
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate

--- a/nova/templates/etc/_nova.conf.tpl
+++ b/nova/templates/etc/_nova.conf.tpl
@@ -33,7 +33,7 @@ rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | defa
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
 max_pool_size = {{ .Values.max_pool_size | default .Values.global.max_pool_size | default 5 }}
-max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 10 }}
+max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 0 }}
 
 # Scheduling
 scheduler_driver_task_period = {{ .Values.scheduler.driver_task_period | default 60 }}


### PR DESCRIPTION
In order to achieve higher availability for outages unrelated to
deployments, we need to run more than one instance of each api.