### PR TITLE
Adding memory_mb_used_gauge & local_gb_used_gauge to openstack_compute_nodes metrics

### DIFF
--- a/nova/values.yaml
+++ b/nova/values.yaml
@@ -86,8 +86,7 @@ pg_metrics:
   db_password: DEFINED-IN-REGION-CHART
   customMetrics:
     openstack_compute_nodes:
-      query: "SELECT compute_nodes.host, aggregate_metadata.value AS availability_zone, compute_nodes.hypervisor_type, compute_nodes.free_disk_gb AS free_disk_gb_gauge, compute_nodes.local_gb AS local_gb_gauge, compute_nodes.free_ram_mb AS free_ram_mb_gauge, compute_nodes.memory_mb AS memory_mb_gauge, compute_nodes.vcpus_used AS vcpus_used_gauge, compute_nodes.vcpus AS vcpus_gauge, compute_nodes.running_vms AS running_vms_gauge from compute_nodes join aggregate_hosts on compute_nodes.host=aggregate_hosts.host join aggregate_metadata on aggregate_hosts.aggregate_id=aggregate_metadata.aggregate_id WHERE compute_nodes.deleted = 0"
-      metrics:
+      query: "SELECT compute_nodes.host, aggregate_metadata.value AS availability_zone, compute_nodes.hypervisor_type, compute_nodes.free_disk_gb AS free_disk_gb_gauge, compute_nodes.local_gb AS local_gb_gauge, compute_nodes.local_gb_used AS local_gb_used_gauge,  compute_nodes.free_ram_mb AS free_ram_mb_gauge, compute_nodes.memory_mb AS memory_mb_gauge, compute_nodes.memory_mb_used AS memory_mb_used_gauge, compute_nodes.vcpus_used AS vcpus_used_gauge, compute_nodes.vcpus AS vcpus_gauge, compute_nodes.running_vms AS running_vms_gauge from compute_nodes join aggregate_hosts on compute_nodes.host=aggregate_hosts.host join aggregate_metadata on aggregate_hosts.aggregate_id=aggregate_metadata.aggregate_id WHERE compute_nodes.deleted = 0;"      metrics:
         - availability_zone:
             usage: "LABEL"
             description: "Availability Zone details from aggregate_metadata table"
@@ -103,12 +102,18 @@ pg_metrics:
         - local_gb_gauge:
             usage: "GAUGE"
             description: "Total local disk size in GB"
+        - local_gb_used_gauge:
+            usage: "GAUGE"
+            description: "Total used local disk size in GB"   
         - free_ram_mb_gauge:
             usage: "GAUGE"
             description: "Free RAM in MiB"
         - memory_mb_gauge:
             usage: "GAUGE"
             description: "Total RAM in MiB"
+        - memory_mb_used_gauge:
+            usage: "GAUGE"
+            description: "Total Used RAM in MiB"            
         - vcpus_used_gauge:
             usage: "GAUGE"
             description: "vCPUs used"

--- a/nova/values.yaml
+++ b/nova/values.yaml
@@ -86,7 +86,8 @@ pg_metrics:
   db_password: DEFINED-IN-REGION-CHART
   customMetrics:
     openstack_compute_nodes:
-      query: "SELECT compute_nodes.host, aggregate_metadata.value AS availability_zone, compute_nodes.hypervisor_type, compute_nodes.free_disk_gb AS free_disk_gb_gauge, compute_nodes.local_gb AS local_gb_gauge, compute_nodes.local_gb_used AS local_gb_used_gauge,  compute_nodes.free_ram_mb AS free_ram_mb_gauge, compute_nodes.memory_mb AS memory_mb_gauge, compute_nodes.memory_mb_used AS memory_mb_used_gauge, compute_nodes.vcpus_used AS vcpus_used_gauge, compute_nodes.vcpus AS vcpus_gauge, compute_nodes.running_vms AS running_vms_gauge from compute_nodes join aggregate_hosts on compute_nodes.host=aggregate_hosts.host join aggregate_metadata on aggregate_hosts.aggregate_id=aggregate_metadata.aggregate_id WHERE compute_nodes.deleted = 0;"      metrics:
+      query: "SELECT compute_nodes.host, aggregate_metadata.value AS availability_zone, compute_nodes.hypervisor_type, compute_nodes.free_disk_gb AS free_disk_gb_gauge, compute_nodes.local_gb AS local_gb_gauge, compute_nodes.local_gb_used AS local_gb_used_gauge, compute_nodes.free_ram_mb AS free_ram_mb_gauge, compute_nodes.memory_mb AS memory_mb_gauge, compute_nodes.memory_mb_used AS memory_mb_used_gauge, compute_nodes.vcpus_used AS vcpus_used_gauge, compute_nodes.vcpus AS vcpus_gauge, compute_nodes.running_vms AS running_vms_gauge from compute_nodes join aggregate_hosts on compute_nodes.host=aggregate_hosts.host join aggregate_metadata on aggregate_hosts.aggregate_id=aggregate_metadata.aggregate_id WHERE compute_nodes.deleted = 0;"      
+      metrics:
         - availability_zone:
             usage: "LABEL"
             description: "Availability Zone details from aggregate_metadata table"


### PR DESCRIPTION
Hi @fwiesel 

After reviewing below links:

https://github.com/openstack/nova/blob/master/nova/scheduler/filters/ram_filter.py#L48-L53
https://specs.openstack.org/openstack/nova-specs/specs/newton/implemented/compute-node-inventory-newton.html

We can conclude : 

sum(memory_mb) =  sum(memory_mb_used) + sum(free_ram_mb)

Hence memory_mb_used% = memory_mb_used/memory_mb
Similarly, local_gb_used% = local_gb_used/local_gb

Hope, the above query replaces the existing grafana query to:
Maximum RAM Usage = max(memory_mb_used/memory_mb)

The above query works well in staging.