### PR TITLE
Editing labels from openstack_snapshots

### DIFF
--- a/cinder/values.yaml
+++ b/cinder/values.yaml
@@ -112,7 +112,7 @@ pg_metrics:
             usage: "GAUGE"
             description: "Size of volumes"
     openstack_snapshots:
-      query: "select snapshots.display_name, snapshots.status, snapshots.project_id, snapshots.volume_id, volumes.host, COUNT(*) AS count_gauge, SUM(volume_size) size_gauge from snapshots join volumes on snapshots.project_id=volumes.project_id GROUP BY snapshots.display_name, snapshots.status, snapshots.project_id, snapshots.volume_id, volumes.host"
+      query: "select snapshots.display_name, snapshots.status, snapshots.project_id, snapshots.volume_id, volumes.host, COUNT(*) AS count_gauge, SUM(volume_size) size_gauge from snapshots join volumes on snapshots.volume_id=volumes.id GROUP BY snapshots.display_name, snapshots.status, snapshots.project_id, snapshots.volume_id, volumes.host"
       metrics:
         - project_id:
             usage: "LABEL"

--- a/cinder/values.yaml
+++ b/cinder/values.yaml
@@ -112,26 +112,23 @@ pg_metrics:
             usage: "GAUGE"
             description: "Size of volumes"
     openstack_snapshots:
-      query: "SELECT project_id, status, COUNT(*) AS count_gauge, SUM(volume_size) size_gauge FROM snapshots GROUP BY  project_id, status"
+      query: "select snapshots.display_name, snapshots.status, snapshots.project_id, snapshots.volume_id, volumes.host, COUNT(*) AS count_gauge, SUM(volume_size) size_gauge from snapshots join volumes on snapshots.project_id=volumes.project_id GROUP BY snapshots.display_name, snapshots.status, snapshots.project_id, snapshots.volume_id, volumes.host"
       metrics:
-        - host:
-            usage: "LABEL"
-            description: "Name of the host"
-        - availability_zone:
-             usage: "LABEL"
-             description: "Availability Zone of the Volume"
-        - volume_type_id:
-            usage: "LABEL"
-            description: "Type of the volume"
         - project_id:
             usage: "LABEL"
             description: "ID of the Project"
+        - host:
+            usage: "LABEL"
+            description: "Name of the host"          
+        - volume_id:
+            usage: "LABEL"
+            description: "Volume ID"
+        - display_name:
+            usage: "LABEL"
+            description: "Name of the volume"
         - status:
             usage: "LABEL"
             description: "Status of the volume"
-        - attach_status:
-            usage: "LABEL"
-            description: "Status of the attachment"
         - count_gauge:
             usage: "GAUGE"
             description: "Number of volumes"

--- a/cinder/values.yaml
+++ b/cinder/values.yaml
@@ -112,7 +112,7 @@ pg_metrics:
             usage: "GAUGE"
             description: "Size of volumes"
     openstack_snapshots:
-      query: "select snapshots.status, snapshots.project_id, volumes.host, COUNT(*) AS count_gauge, SUM(volume_size) size_gauge from snapshots join volumes on snapshots.volume_id=volumes.id GROUP BY snapshots.display_name, snapshots.status, snapshots.project_id, snapshots.volume_id, volumes.host"
+      query: "select snapshots.status, snapshots.project_id, volumes.host, COUNT(*) AS count_gauge, SUM(volume_size) size_gauge from snapshots join volumes on snapshots.volume_id=volumes.id GROUP BY snapshots.status, snapshots.project_id, volumes.host"
       metrics:
         - project_id:
             usage: "LABEL"
@@ -122,13 +122,13 @@ pg_metrics:
             description: "Name of the host"          
         - status:
             usage: "LABEL"
-            description: "Status of the volume"
+            description: "Status of the Snapshot"
         - count_gauge:
             usage: "GAUGE"
-            description: "Number of volumes"
+            description: "Number of Snapshots"
         - size_gauge:
             usage: "GAUGE"
-            description: "Size of volumes"
+            description: "Size of Snapshots"
 
 postgres:
   name: cinder

--- a/cinder/values.yaml
+++ b/cinder/values.yaml
@@ -112,7 +112,7 @@ pg_metrics:
             usage: "GAUGE"
             description: "Size of volumes"
     openstack_snapshots:
-      query: "select snapshots.display_name, snapshots.status, snapshots.project_id, snapshots.volume_id, volumes.host, COUNT(*) AS count_gauge, SUM(volume_size) size_gauge from snapshots join volumes on snapshots.volume_id=volumes.id GROUP BY snapshots.display_name, snapshots.status, snapshots.project_id, snapshots.volume_id, volumes.host"
+      query: "select snapshots.status, snapshots.project_id, volumes.host, COUNT(*) AS count_gauge, SUM(volume_size) size_gauge from snapshots join volumes on snapshots.volume_id=volumes.id GROUP BY snapshots.display_name, snapshots.status, snapshots.project_id, snapshots.volume_id, volumes.host"
       metrics:
         - project_id:
             usage: "LABEL"
@@ -120,12 +120,6 @@ pg_metrics:
         - host:
             usage: "LABEL"
             description: "Name of the host"          
-        - volume_id:
-            usage: "LABEL"
-            description: "Volume ID"
-        - display_name:
-            usage: "LABEL"
-            description: "Name of the volume"
         - status:
             usage: "LABEL"
             description: "Status of the volume"


### PR DESCRIPTION
@fwiesel 

After reviewing history of cinder/values.yaml file i.e. i found https://github.com/sapcc/openstack-helm/commit/a1225abc53b94d6d18bf6fdef9a046aebc350fbf#diff-ef3489baee269a4668d44fa7e94d0b38 was the inital metrics for cinder.

In which metric openstack_snapshots had no columns such attach_status, availability_zones, etc in snapshots table (maybe a copy-paste of labels from openstack_volumes). I noticed this when Joachim confirmed maia was showing same values across all the labels (discussion in m3monitor). 

I have tested this query in staging, the desired results are seen in prometheus & maia. Please validate & approve.