### PR TITLE
Vice president

### DIFF
--- a/barbican/templates/ingress.yaml
+++ b/barbican/templates/ingress.yaml
@@ -8,6 +8,10 @@ metadata:
     system: openstack
     type: api
     component: barbican
+  {{- if .Values.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   tls:
      - secretName: tls-{{ include "barbican_api_endpoint_host_public" . | replace "." "-" }}

--- a/cinder/templates/api-ingress.yaml
+++ b/cinder/templates/api-ingress.yaml
@@ -7,6 +7,10 @@ metadata:
     system: openstack
     type: api
     component: cinder
+  {{- if .Values.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   tls:
      - secretName: tls-{{ include "cinder_api_endpoint_host_public" . | replace "." "-"}}

--- a/glance/templates/ingress.yaml
+++ b/glance/templates/ingress.yaml
@@ -9,6 +9,9 @@ metadata:
     component: glance
   annotations:
      ingress.kubernetes.io/proxy-request-buffering: "off"
+     {{- if .Values.vice_president }}
+     vice-president: "true"
+     {{- end }}
 spec:
   tls:
     - secretName: tls-{{ include "glance_api_endpoint_host_public" . | replace "." "-" }}

--- a/horizon/templates/ingress.yaml
+++ b/horizon/templates/ingress.yaml
@@ -7,7 +7,10 @@ metadata:
     system: openstack
     type: api
     component: horizon
-
+  {{- if .Values.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   tls:
      - secretName:  tls-{{ include "horizon_endpoint_host" . | replace "." "-" }}

--- a/ironic/templates/api-ingress.yaml
+++ b/ironic/templates/api-ingress.yaml
@@ -8,6 +8,10 @@ metadata:
     system: openstack
     type: api
     component: ironic
+  {{- if .Values.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   tls:
      - secretName: tls-{{ include "ironic_api_endpoint_host_public" . | replace "." "-" }}

--- a/ironic/templates/console-ingress.yaml
+++ b/ironic/templates/console-ingress.yaml
@@ -7,6 +7,10 @@ metadata:
     system: openstack
     type: api
     component: ironic
+  {{- if .Values.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   tls:
      - secretName: tls-{{ include "ironic_console_endpoint_host_public" . | replace "." "-" }}

--- a/ironic/templates/inspector-ingress.yaml
+++ b/ironic/templates/inspector-ingress.yaml
@@ -8,6 +8,10 @@ metadata:
     system: openstack
     type: inspector
     component: ironic
+  {{- if .Values.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   tls:
     - secretName: tls-{{ include "ironic_inspector_endpoint_host_public" . | replace "." "-" }}

--- a/manila/templates/api-ingress.yaml
+++ b/manila/templates/api-ingress.yaml
@@ -7,6 +7,10 @@ metadata:
     system: openstack
     type: api
     component: manila
+  {{- if .Values.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   tls:
      - secretName: tls-{{include "manila_api_endpoint_host_public" . | replace "." "-" }}

--- a/neutron/templates/server-ingress.yaml
+++ b/neutron/templates/server-ingress.yaml
@@ -7,10 +7,6 @@ metadata:
     system: openstack
     type: api
     component: neutron
-  {{- if .Values.vice_president }}
-  annotations:
-    vice-president: "true"
-  {{- end }}
 spec:
   tls:
      - secretName: tls-{{include "neutron_api_endpoint_host_public" . | replace "." "-" }}

--- a/neutron/templates/server-ingress.yaml
+++ b/neutron/templates/server-ingress.yaml
@@ -7,6 +7,10 @@ metadata:
     system: openstack
     type: api
     component: neutron
+  {{- if .Values.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   tls:
      - secretName: tls-{{include "neutron_api_endpoint_host_public" . | replace "." "-" }}

--- a/nova/templates/api-ingress.yaml
+++ b/nova/templates/api-ingress.yaml
@@ -7,6 +7,10 @@ metadata:
     system: openstack
     type: api
     component: nova
+  {{- if .Values.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   tls:
      - secretName: tls-{{include "nova_api_endpoint_host_public" . | replace "." "-" }}

--- a/nova/templates/console-ingress.yaml
+++ b/nova/templates/console-ingress.yaml
@@ -9,6 +9,9 @@ metadata:
     component: nova
   annotations:
     ingress.kubernetes.io/rewrite-target: /
+    {{- if .Values.vice_president }}
+    vice-president: "true"
+    {{- end }}
 spec:
   tls:
      - secretName: tls-{{include "nova_console_endpoint_host_public" . | replace "." "-" }}


### PR DESCRIPTION
Switch services to the vice president.
This PR introduces a switch that annotates the ingresses if the corresponding parameter in the regional values file is set. The actual switch to the vp will happen when the parameter is set and the cert,key is deleted in cc-regions. 
We (me + @Carthaca ) did and tested the same already for designate.
Everyone ok with this?
