### PR TITLE
Nova policy: set permission "quota-sets:detail" to same as "quota-sets:show"

### DIFF
--- a/nova/templates/etc/_nova-policy.json.tpl
+++ b/nova/templates/etc/_nova-policy.json.tpl
@@ -432,7 +432,7 @@
     "os_compute_api:os-quota-sets:defaults": "rule:context_is_viewer",
     "os_compute_api:os-quota-sets:update": "rule:context_is_admin",
     "os_compute_api:os-quota-sets:delete": "rule:context_is_admin",
-    "os_compute_api:os-quota-sets:detail": "rule:context_is_admin",
+    "os_compute_api:os-quota-sets:detail": "rule:context_is_viewer",
     "os_compute_api:os-quota-class-sets:update": "rule:context_is_admin",
     "os_compute_api:os-quota-class-sets:show": "rule:context_is_admin or quota_class:%(quota_class)s",
     "os_compute_api:os-quota-class-sets:discoverable": "@",


### PR DESCRIPTION
A customer complained about getting "403 Forbidden" on the `/os-quota-sets/:project_id/detail` endpoint. As far as I can see, the only difference to `/os-quota-sets/:project_id` without `/detail` is that usage is reported. This information is accessible to a viewer anyway because they can just list all instances and other resources, so there's no point in hiding it from them here.