### PR TITLE
Vcenter exporter integration

### DIFF
--- a/openstack/templates/vcenter-operator.yaml
+++ b/openstack/templates/vcenter-operator.yaml
@@ -20,6 +20,32 @@ data:
   {{$key}}: {{ toJson $value }}
 {{- end }}
 {{ (.Files.Glob "vcenter-operator/*").AsConfig | indent 2 }}
+{{- if .Values.vcenter_exporter.enabled }}
+  vcenter_exporter_enabled: True
+  vcenter_exporter_image: {{ .Values.vcenter_exporter.image_version | quote  }}
+  vcenter_exporter_docker_repo: {{ .Values.vcenter_exporter.docker_repo | quote }}
+  vcenter_exporter_ignore_ssl: {{ .Values.vcenter_exporter.ignore_ssl | quote }}
+  vcenter_exporter_listen_port: {{ .Values.vcenter_exporter.listen_port | quote }}
+  vcenter_exporter_interval: {{ .Values.vcenter_exporter.interval | quote }}
+{{- if .Values.vcenter_exporter.shorter_names_regex }}
+  vcenter_exporter_shorter_names_regex: {{ .Values.vcenter_exporter.shorter_names_regex | quote}}
+{{- end }}
+{{- if .Values.vcenter_exporter.host_match_regex }}
+  vcenter_host_match_regex: True
+{{- end}}
+
+{{- if .Values.cluster_exporter_types }}
+  vcenter_exporter_cluster_exporter_types: {{- range $i, $exporter_type := .Values.cluster_exporter_types }}
+    - name: {{$exporter_type.name | quote }}
+      collector: {{$exporter_type.collector | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.datacenter_exporter_types }}
+  vcenter_exporter_datacenter_exporter_types: {{- range $i, $exporter_type := .Values.datacenter_exporter_types }}
+    - name: {{$exporter_vcentertype.name | quote }}
+      collector {{$exporter_type.collector | quote }}
+{{- end }}
+{{- end }}
 ---
 kind: Deployment
 apiVersion: extensions/v1beta1

--- a/openstack/templates/vcenter-operator.yaml
+++ b/openstack/templates/vcenter-operator.yaml
@@ -20,32 +20,6 @@ data:
   {{$key}}: {{ toJson $value }}
 {{- end }}
 {{ (.Files.Glob "vcenter-operator/*").AsConfig | indent 2 }}
-{{- if .Values.vcenter_exporter.enabled }}
-  vcenter_exporter_enabled: True
-  vcenter_exporter_image: {{ .Values.vcenter_exporter.image_version | quote  }}
-  vcenter_exporter_docker_repo: {{ .Values.vcenter_exporter.docker_repo | quote }}
-  vcenter_exporter_ignore_ssl: {{ .Values.vcenter_exporter.ignore_ssl | quote }}
-  vcenter_exporter_listen_port: {{ .Values.vcenter_exporter.listen_port | quote }}
-  vcenter_exporter_interval: {{ .Values.vcenter_exporter.interval | quote }}
-{{- if .Values.vcenter_exporter.shorter_names_regex }}
-  vcenter_exporter_shorter_names_regex: {{ .Values.vcenter_exporter.shorter_names_regex | quote}}
-{{- end }}
-{{- if .Values.vcenter_exporter.host_match_regex }}
-  vcenter_host_match_regex: True
-{{- end}}
-
-{{- if .Values.cluster_exporter_types }}
-  vcenter_exporter_cluster_exporter_types: {{- range $i, $exporter_type := .Values.cluster_exporter_types }}
-    - name: {{$exporter_type.name | quote }}
-      collector: {{$exporter_type.collector | quote }}
-{{- end }}
-{{- end }}
-{{- if .Values.datacenter_exporter_types }}
-  vcenter_exporter_datacenter_exporter_types: {{- range $i, $exporter_type := .Values.datacenter_exporter_types }}
-    - name: {{$exporter_vcentertype.name | quote }}
-      collector {{$exporter_type.collector | quote }}
-{{- end }}
-{{- end }}
 ---
 kind: Deployment
 apiVersion: extensions/v1beta1

--- a/openstack/templates/vcenter-operator.yaml
+++ b/openstack/templates/vcenter-operator.yaml
@@ -21,6 +21,32 @@ data:
   {{ $key }}: {{if hasPrefix "\"" $str }}{{ $str }}{{ else }}{{ quote $str }}{{ end }}
 {{- end }}
 {{ (.Files.Glob "vcenter-operator/*").AsConfig | indent 2 }}
+{{- if .Values.vcenter_exporter.enabled }}
+  vcenter_exporter_enabled: True
+  vcenter_exporter_image: {{ .Values.vcenter_exporter.image_version | quote  }}
+  vcenter_exporter_docker_repo: {{ .Values.vcenter_exporter.docker_repo | quote }}
+  vcenter_exporter_ignore_ssl: {{ .Values.vcenter_exporter.ignore_ssl | quote }}
+  vcenter_exporter_listen_port: {{ .Values.vcenter_exporter.listen_port | quote }}
+  vcenter_exporter_interval: {{ .Values.vcenter_exporter.interval | quote }}
+{{- if .Values.vcenter_exporter.shorter_names_regex }}
+  vcenter_exporter_shorter_names_regex: {{ .Values.vcenter_exporter.shorter_names_regex | quote}}
+{{- end }}
+{{- if .Values.vcenter_exporter.host_match_regex }}
+  vcenter_host_match_regex: True
+{{- end}}
+
+{{- if .Values.cluster_exporter_types }}
+  vcenter_exporter_cluster_exporter_types: {{- range $i, $exporter_type := .Values.cluster_exporter_types }}
+    - name: {{$exporter_type.name | quote }}
+      collector: {{$exporter_type.collector | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.datacenter_exporter_types }}
+  vcenter_exporter_datacenter_exporter_types: {{- range $i, $exporter_type := .Values.datacenter_exporter_types }}
+    - name: {{$exporter_vcentertype.name | quote }}
+      collector {{$exporter_type.collector | quote }}
+{{- end }}
+{{- end }}
 ---
 kind: Deployment
 apiVersion: extensions/v1beta1

--- a/openstack/templates/vcenter-operator.yaml
+++ b/openstack/templates/vcenter-operator.yaml
@@ -21,32 +21,6 @@ data:
   {{ $key }}: {{if hasPrefix "\"" $str }}{{ $str }}{{ else }}{{ quote $str }}{{ end }}
 {{- end }}
 {{ (.Files.Glob "vcenter-operator/*").AsConfig | indent 2 }}
-{{- if .Values.vcenter_exporter.enabled }}
-  vcenter_exporter_enabled: True
-  vcenter_exporter_image: {{ .Values.vcenter_exporter.image_version | quote  }}
-  vcenter_exporter_docker_repo: {{ .Values.vcenter_exporter.docker_repo | quote }}
-  vcenter_exporter_ignore_ssl: {{ .Values.vcenter_exporter.ignore_ssl | quote }}
-  vcenter_exporter_listen_port: {{ .Values.vcenter_exporter.listen_port | quote }}
-  vcenter_exporter_interval: {{ .Values.vcenter_exporter.interval | quote }}
-{{- if .Values.vcenter_exporter.shorter_names_regex }}
-  vcenter_exporter_shorter_names_regex: {{ .Values.vcenter_exporter.shorter_names_regex | quote}}
-{{- end }}
-{{- if .Values.vcenter_exporter.host_match_regex }}
-  vcenter_host_match_regex: True
-{{- end}}
-
-{{- if .Values.cluster_exporter_types }}
-  vcenter_exporter_cluster_exporter_types: {{- range $i, $exporter_type := .Values.cluster_exporter_types }}
-    - name: {{$exporter_type.name | quote }}
-      collector: {{$exporter_type.collector | quote }}
-{{- end }}
-{{- end }}
-{{- if .Values.datacenter_exporter_types }}
-  vcenter_exporter_datacenter_exporter_types: {{- range $i, $exporter_type := .Values.datacenter_exporter_types }}
-    - name: {{$exporter_vcentertype.name | quote }}
-      collector {{$exporter_type.collector | quote }}
-{{- end }}
-{{- end }}
 ---
 kind: Deployment
 apiVersion: extensions/v1beta1

--- a/openstack/templates/vcenter-operator.yaml
+++ b/openstack/templates/vcenter-operator.yaml
@@ -17,7 +17,8 @@ data:
   nova_service_user: {{  .Values.global.nova_service_user }}
   vcenter_nanny_image: {{ .Values.global.image_repository}}/{{ .Values.global.image_namespace}}/vcenter-nanny:{{ .Values.vcenter_operator.image_version_vcenter_nanny }}
 {{- range $key, $value := .Values.vcenter_operator }}
-  {{$key}}: {{ toJson $value }}
+  {{- $str := toJson $value }}
+  {{ $key }}: {{if hasPrefix "\"" $str }}{{ $str }}{{ else }}{{ quote $str }}{{ end }}
 {{- end }}
 {{ (.Files.Glob "vcenter-operator/*").AsConfig | indent 2 }}
 ---

--- a/openstack/values.yaml
+++ b/openstack/values.yaml
@@ -233,6 +233,13 @@ vcenter_operator:
     vcenter_nanny_interval: 720
     # really delete entities after how many iterations
     vcenter_nanny_iterations: 14
+    vcenter_exporter:
+      enabled: DEFINED-IN-REGION-CHART
+      image_version: DEFINED-IN-REGION-CHART
+      listen_port: 9102
+      interval: 120
+      name_shortening_regex: DEFINED-IN-REGION-CHART
+      docker_repo: DEFINED-IN-REGION-CHART
 
 keystone:
   image_version_keystone_m3: DEFINED-IN-REGION-CHART

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -1,0 +1,57 @@
+{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
+{{% for exporter_type in vcenter_exporter_cluster_exporter_types %}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  namespace: monsoon3
+  labels:
+    system: openstack
+    service: metrics
+    component: configuration
+data:
+  config-{{name}}{{ exporter_type['name'] }}'.yaml: |
+    main:
+      availability_zone: '{{ availability_zone }}'
+      listen_port: '{{ vcenter_exporter_listen_port }}'
+      host: '{{ host }}'
+      user: '{{ username}}'
+      password: '{{ password }}'
+      port: 443
+      ignore_ssl: {{ vcenter_exporter_ignore_ssl }}
+      interval: {{vcenter_exporter_interval}}
+      log: 'INFO'
+      {{% if vcneter_exporter_shorter_names_regex is defined %}}
+      shorter_names_regex: '{{vcenter_exporter_shorter_names_regex}}'
+      {{% endif %}}
+      {{% if vcenter_exporter_host_match_regex is defined %}}
+      host_match_regex: '{{ name }}'
+      {{% endif %}}
+      ignore_match_regex: '(^c_blackbox_|^datapath_|^canary_).*'
+      vm_metrics:
+      - 'cpu.latency.average'
+      - 'cpu.usage.average'
+      - 'cpu.usagemhz.average'
+      - 'cpu.wait.summation'
+      - 'disk.usage.average'
+      - 'disk.numberRead.summation'
+      - 'disk.numberWrite.summation'
+      - 'mem.usage.average'
+      - 'net.usage.average'
+      - 'net.bytesRx.average'
+      - 'net.bytesTx.average'
+      - 'net.droppedRx.summation'
+      - 'net.droppedTx.summation'
+      - 'net.errorsRx.summation'
+      - 'net.errorsTx.summation'
+      - 'net.packetsRx.summation'
+      - 'net.packetsTx.summation'
+      - 'virtualDisk.read.average'
+      - 'virtualDisk.write.average'
+      - 'virtualDisk.readIOI.latest'
+      - 'virtualDisk.writeIOI.latest'
+      - 'virtualDisk.totalReadLatency.average'
+      - 'virtualDisk.totalWriteLatency.average'
+{{% endfor %}}
+{{% endif %}}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -1,4 +1,5 @@
-{% if vcenter_exporter['enabled'] == "true" %}
+{% if ((vcenter_exporter is defined) and
+       (vcenter_exporter['enabled'] == "true")) %}
 {% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 apiVersion: v1

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -1,4 +1,4 @@
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% if vcenter_exporter['enabled'] == "true" %}
 {% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 apiVersion: v1
@@ -14,7 +14,6 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-<<<<<<< HEAD
       listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username}}'
@@ -22,22 +21,10 @@ data:
       port: 443{% if vcenter_exporter['ignore_ssl'] == "true" %}
       ignore_ssl: True{% else %}
       ignore_ssl: False{% endif %}
-      interval: {{vcenter_exporter['interval']}}
+      interval: {{ vcenter_exporter['interval']}}
       log: 'INFO'
       {% if vcenter_exporter['shorter_names_regex'] is defined %}
       shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
-=======
-      listen_port: '{{ vcenter_exporter['listen_port'] }}'
-      host: '{{ host }}'
-      user: '{{ username}}'
-      password: '{{ password }}'
-      port: 443
-      ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
-      interval: {{vcenter_exporter['interval']}}
-      log: 'INFO'
-      {% if vcenter_exporter['shorter_names_regex'] is defined %}
-      shorter_names_regex: '{{ vcenter_exporter['shorter_names_regex'] }}'
->>>>>>> adjusted and validated jinja templates
       {% endif %}
       {% if vcenter_exporter['host_match_regex'] is defined %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -16,12 +16,12 @@ data:
       availability_zone: '{{ availability_zone }}'
       listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
-      user: '{{ username}}'
+      user: '{{ username }}'
       password: '{{ password }}'
       port: 443{% if vcenter_exporter['ignore_ssl'] == "true" %}
       ignore_ssl: True{% else %}
       ignore_ssl: False{% endif %}
-      interval: {{ vcenter_exporter['interval']}}
+      interval: {{ vcenter_exporter['interval'] }}
       log: 'INFO'
       {% if vcenter_exporter['shorter_names_regex'] is defined %}
       shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -14,6 +14,7 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
+<<<<<<< HEAD
       listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username}}'
@@ -25,6 +26,18 @@ data:
       log: 'INFO'
       {% if vcenter_exporter['shorter_names_regex'] is defined %}
       shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
+=======
+      listen_port: '{{ vcenter_exporter['listen_port'] }}'
+      host: '{{ host }}'
+      user: '{{ username}}'
+      password: '{{ password }}'
+      port: 443
+      ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
+      interval: {{vcenter_exporter['interval']}}
+      log: 'INFO'
+      {% if vcenter_exporter['shorter_names_regex'] is defined %}
+      shorter_names_regex: '{{ vcenter_exporter['shorter_names_regex'] }}'
+>>>>>>> adjusted and validated jinja templates
       {% endif %}
       {% if vcenter_exporter['host_match_regex'] is defined %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -1,36 +1,32 @@
-{% if vcenter_exporter_enabled == "true" %}
-{% set exporter_types = vcenter_exporter_cluster_exporter_types.split(';') %}
-{% for exporter_type in exporter_types %}
-{% set keyvals = exporter_type.split(',') %}
-{% set exporter_type_name = keyvals[0].split(':')[1] %}
-{% set exporter_type_collector = keyvals[1].split(':')[1] %}
+{% if vcenter_exporter['enabled'] == "true" %}
+{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: monsoon3
   labels:
     system: openstack
     service: metrics
     component: configuration
 data:
-  config-{{ name }}-{{ exporter_type_name }}.yaml: |
+  config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: "{{ vcenter_exporter_listen_port }}"
+      listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username }}'
       password: '{{ password }}'
-      port: 443{% if vcenter_exporter_ignore_ssl == "true" %}
+      port: 443{% if vcenter_exporter['ignore_ssl'] == "true" %}
       ignore_ssl: True{% else %}
       ignore_ssl: False{% endif %}
-      interval: {{ vcenter_exporter_interval }}
+      interval: {{ vcenter_exporter['interval'] }}
       log: 'INFO'
-      {% if vcenter_exporter_shorter_names_regex is defined %}
-      shorter_names_regex: "{{ vcenter_exporter_shorter_names_regex }}"
+      {% if vcenter_exporter['shorter_names_regex'] is defined %}
+      shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
       {% endif %}
-      {% if vcenter_exporter_host_match_regex is defined %}
+      {% if vcenter_exporter['host_match_regex'] is defined %}
       host_match_regex: '{{ name }}'
       {% endif %}
       ignore_match_regex: '(^c_blackbox_|^datapath_|^canary_).*'

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -1,32 +1,36 @@
-{% if vcenter_exporter['enabled'] == "true" %}
-{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
+{% if vcenter_exporter_enabled == "true" %}
+{% set exporter_types = vcenter_exporter_cluster_exporter_types.split(';') %}
+{% for exporter_type in exporter_types %}
+{% set keyvals = exporter_type.split(',') %}
+{% set exporter_type_name = keyvals[0].split(':')[1] %}
+{% set exporter_type_collector = keyvals[1].split(':')[1] %}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   namespace: monsoon3
   labels:
     system: openstack
     service: metrics
     component: configuration
 data:
-  config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
+  config-{{ name }}-{{ exporter_type_name }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: "{{ vcenter_exporter['listen_port'] }}"
+      listen_port: "{{ vcenter_exporter_listen_port }}"
       host: '{{ host }}'
       user: '{{ username }}'
       password: '{{ password }}'
-      port: 443{% if vcenter_exporter['ignore_ssl'] == "true" %}
+      port: 443{% if vcenter_exporter_ignore_ssl == "true" %}
       ignore_ssl: True{% else %}
       ignore_ssl: False{% endif %}
-      interval: {{ vcenter_exporter['interval'] }}
+      interval: {{ vcenter_exporter_interval }}
       log: 'INFO'
-      {% if vcenter_exporter['shorter_names_regex'] is defined %}
-      shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
+      {% if vcenter_exporter_shorter_names_regex is defined %}
+      shorter_names_regex: "{{ vcenter_exporter_shorter_names_regex }}"
       {% endif %}
-      {% if vcenter_exporter['host_match_regex'] is defined %}
+      {% if vcenter_exporter_host_match_regex is defined %}
       host_match_regex: '{{ name }}'
       {% endif %}
       ignore_match_regex: '(^c_blackbox_|^datapath_|^canary_).*'

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -14,6 +14,7 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
+<<<<<<< HEAD
       listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username }}'
@@ -25,6 +26,18 @@ data:
       log: 'INFO'
       {% if vcenter_exporter['shorter_names_regex'] is defined %}
       shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
+=======
+      listen_port: '{{ vcenter_exporter['listen_port'] }}'
+      host: '{{ host }}'
+      user: '{{ username}}'
+      password: '{{ password }}'
+      port: 443
+      ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
+      interval: {{vcenter_exporter['interval']}}
+      log: 'INFO'
+      {% if vcenter_exporter['shorter_names_regex'] is defined %}
+      shorter_names_regex: '{{ vcenter_exporter['shorter_names_regex'] }}'
+>>>>>>> adjusted and validated jinja templates
       {% endif %}
       {% if vcenter_exporter['host_match_regex'] is defined %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -14,7 +14,6 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-<<<<<<< HEAD
       listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username }}'
@@ -26,18 +25,6 @@ data:
       log: 'INFO'
       {% if vcenter_exporter['shorter_names_regex'] is defined %}
       shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
-=======
-      listen_port: '{{ vcenter_exporter['listen_port'] }}'
-      host: '{{ host }}'
-      user: '{{ username}}'
-      password: '{{ password }}'
-      port: 443
-      ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
-      interval: {{vcenter_exporter['interval']}}
-      log: 'INFO'
-      {% if vcenter_exporter['shorter_names_regex'] is defined %}
-      shorter_names_regex: '{{ vcenter_exporter['shorter_names_regex'] }}'
->>>>>>> adjusted and validated jinja templates
       {% endif %}
       {% if vcenter_exporter['host_match_regex'] is defined %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -4,14 +4,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: monsoon3
   labels:
     system: openstack
     service: metrics
     component: configuration
 data:
-  config-{{name}}{{ exporter_type['name'] }}'.yaml: |
+  config-{{ name }}-{{ exporter_type['name'] }}'.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
       listen_port: '{{ vcenter_exporter_listen_port }}'

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -22,7 +22,7 @@ data:
       ignore_ssl: {{ vcenter_exporter_ignore_ssl }}
       interval: {{vcenter_exporter_interval}}
       log: 'INFO'
-      {{% if vcneter_exporter_shorter_names_regex is defined %}}
+      {{% if vcenter_exporter_shorter_names_regex is defined %}}
       shorter_names_regex: '{{vcenter_exporter_shorter_names_regex}}'
       {{% endif %}}
       {{% if vcenter_exporter_host_match_regex is defined %}}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -1,5 +1,5 @@
-{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
-{{% for exporter_type in vcenter_exporter_cluster_exporter_types %}}
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -14,20 +14,20 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}'.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: '{{ vcenter_exporter_listen_port }}'
+      listen_port: '{{ vcenter_exporter['listen_port'] }}'
       host: '{{ host }}'
       user: '{{ username}}'
       password: '{{ password }}'
       port: 443
-      ignore_ssl: {{ vcenter_exporter_ignore_ssl }}
-      interval: {{vcenter_exporter_interval}}
+      ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
+      interval: {{vcenter_exporter['interval']}}
       log: 'INFO'
-      {{% if vcenter_exporter_shorter_names_regex is defined %}}
-      shorter_names_regex: '{{vcenter_exporter_shorter_names_regex}}'
-      {{% endif %}}
-      {{% if vcenter_exporter_host_match_regex is defined %}}
+      {% if vcenter_exporter['shorter_names_regex'] is defined %}
+      shorter_names_regex: '{{ vcenter_exporter['shorter_names_regex'] }}'
+      {% endif %}
+      {% if vcenter_exporter['host_match_regex'] is defined %}
       host_match_regex: '{{ name }}'
-      {{% endif %}}
+      {% endif %}
       ignore_match_regex: '(^c_blackbox_|^datapath_|^canary_).*'
       vm_metrics:
       - 'cpu.latency.average'
@@ -53,5 +53,5 @@ data:
       - 'virtualDisk.writeIOI.latest'
       - 'virtualDisk.totalReadLatency.average'
       - 'virtualDisk.totalWriteLatency.average'
-{{% endfor %}}
-{{% endif %}}
+{% endfor %}
+{% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -11,19 +11,20 @@ metadata:
     service: metrics
     component: configuration
 data:
-  config-{{ name }}-{{ exporter_type['name'] }}'.yaml: |
+  config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: '{{ vcenter_exporter['listen_port'] }}'
+      listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username}}'
       password: '{{ password }}'
-      port: 443
-      ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
+      port: 443{% if vcenter_exporter['ignore_ssl'] == "true" %}
+      ignore_ssl: True{% else %}
+      ignore_ssl: False{% endif %}
       interval: {{vcenter_exporter['interval']}}
       log: 'INFO'
       {% if vcenter_exporter['shorter_names_regex'] is defined %}
-      shorter_names_regex: '{{ vcenter_exporter['shorter_names_regex'] }}'
+      shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
       {% endif %}
       {% if vcenter_exporter['host_match_regex'] is defined %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -1,5 +1,5 @@
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
-{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
+{% if enabled is defined and enabled == True %}
+{% for exporter_type in cluster_exporter_types %}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
+          image: {{ docker_repo}}/vcenter-exporter:{{ image_version | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -46,6 +46,6 @@ spec:
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ vcenter_exporter['listen_port'] }}
+              containerPort: {{ listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -1,10 +1,14 @@
-{% if vcenter_exporter['enabled'] == "true" %}
-{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
+{% if vcenter_exporter_enabled == "true" %}
+{% set exporter_types = vcenter_exporter_cluster_exporter_types.split(';') %}
+{% for exporter_type in exporter_types %}
+{% set keyvals = exporter_type.split(',') %}
+{% set exporter_type_name = keyvals[0].split(':')[1] %}
+{% set exporter_type_collector = keyvals[1].split(':')[1] %}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   namespace: monsoon3
   labels:
     system: openstack
@@ -20,32 +24,32 @@ spec:
   template:
     metadata:
       labels:
-        component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+        component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
     spec:
       nodeSelector:
         zone: farm
       volumes:
         - name: maia-etc
           configMap:
-            name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+            name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
+          image: {{ vcenter_exporter_docker_repo}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
           args:
             - /vcenter-exporter/vcenter-exporter.py
             - -c
-            - /maia-etc/config-{{ name }}-{{ exporter_type['name'] }}.yaml
+            - /maia-etc/config-{{ name }}-{{ exporter_type_name }}.yaml
             - -t
-            - {{ exporter_type['name'] }}
+            - {{ exporter_type_name }}
           volumeMounts:
             - mountPath: /maia-etc
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ vcenter_exporter['listen_port'] }}
+              containerPort: {{ vcenter_exporter_listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -1,4 +1,4 @@
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% if vcenter_exporter['enabled'] == "true" %}
 {% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 apiVersion: extensions/v1beta1

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -4,7 +4,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: monsoon3
   labels:
     system: openstack
@@ -20,14 +20,14 @@ spec:
   template:
     metadata:
       labels:
-        component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+        component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
     spec:
       nodeSelector:
         zone: farm
       volumes:
         - name: maia-etc
           configMap:
-            name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+            name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
@@ -38,7 +38,7 @@ spec:
           args:
             - /vcenter-exporter/vcenter-exporter.py
             - -c
-            - /maia-etc/config-{{ name }}{{ exporter_type['name'] }}.yaml
+            - /maia-etc/config-{{ name }}-{{ exporter_type['name'] }}.yaml
             - -t
             - {{ exporter_type['name'] }}
           volumeMounts:

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ docker_repo}}/vcenter-exporter:{{ image_version | replace ("string:", "") }}
+          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -46,6 +46,6 @@ spec:
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ listen_port }}
+              containerPort: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -1,5 +1,5 @@
-{% if enabled is defined and enabled == True %}
-{% for exporter_type in cluster_exporter_types %}
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ docker_repo}}/vcenter-exporter:{{ image_version | replace ("string:", "") }}
+          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -46,6 +46,6 @@ spec:
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ listen_port }}
+              containerPort: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -1,0 +1,51 @@
+{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
+{{% for exporter_type in vcenter_exporter_cluster_exporter_types %}}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  namespace: monsoon3
+  labels:
+    system: openstack
+    service: metrics
+
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+    spec:
+      nodeSelector:
+        zone: farm
+      volumes:
+        - name: maia-etc
+          configMap:
+            name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+      containers:
+        - name: vcenter-exporter
+          # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
+          image: {{ vcenter_exporter_docker_repo}}/vcenter-exporter:{{ vcenter_exporter_image | replace ("string:", "") }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - python
+          args:
+            - /vcenter-exporter/vcenter-exporter.py
+            - -c
+            - /maia-etc/config-{{ name }}{{ exporter_type['name'] }}.yaml
+            - -t
+            - {{ exporter_type['name'] }}
+          volumeMounts:
+            - mountPath: /maia-etc
+              name: maia-etc
+          ports:
+            - name: metrics
+              containerPort: {{ vcenter_exporter_listen_port }}
+{{% endif %}}
+{{% endfor %}}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -1,5 +1,5 @@
-{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
-{{% for exporter_type in vcenter_exporter_cluster_exporter_types %}}
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ vcenter_exporter_docker_repo}}/vcenter-exporter:{{ vcenter_exporter_image | replace ("string:", "") }}
+          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -46,6 +46,6 @@ spec:
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ vcenter_exporter_listen_port }}
-{{% endif %}}
-{{% endfor %}}
+              containerPort: {{ vcenter_exporter['listen_port'] }}
+{% endfor %}
+{% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -1,14 +1,10 @@
-{% if vcenter_exporter_enabled == "true" %}
-{% set exporter_types = vcenter_exporter_cluster_exporter_types.split(';') %}
-{% for exporter_type in exporter_types %}
-{% set keyvals = exporter_type.split(',') %}
-{% set exporter_type_name = keyvals[0].split(':')[1] %}
-{% set exporter_type_collector = keyvals[1].split(':')[1] %}
+{% if vcenter_exporter['enabled'] == "true" %}
+{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: monsoon3
   labels:
     system: openstack
@@ -24,32 +20,32 @@ spec:
   template:
     metadata:
       labels:
-        component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+        component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
     spec:
       nodeSelector:
         zone: farm
       volumes:
         - name: maia-etc
           configMap:
-            name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+            name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ vcenter_exporter_docker_repo}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
+          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
           args:
             - /vcenter-exporter/vcenter-exporter.py
             - -c
-            - /maia-etc/config-{{ name }}-{{ exporter_type_name }}.yaml
+            - /maia-etc/config-{{ name }}-{{ exporter_type['name'] }}.yaml
             - -t
-            - {{ exporter_type_name }}
+            - {{ exporter_type['name'] }}
           volumeMounts:
             - mountPath: /maia-etc
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ vcenter_exporter_listen_port }}
+              containerPort: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -1,4 +1,5 @@
-{% if vcenter_exporter['enabled'] == "true" %}
+{% if ((vcenter_exporter is defined) and
+       (vcenter_exporter['enabled'] == "true")) %}
 {% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 apiVersion: extensions/v1beta1

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_deployment.yaml.j2
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
+          image: {{ docker_repo}}/vcenter-exporter:{{ image_version | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -46,6 +46,6 @@ spec:
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ vcenter_exporter['listen_port'] }}
+              containerPort: {{ listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -1,5 +1,5 @@
-{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
-{{% for exporter_type in vcenter_exporter_cluster_exporter_types %}}
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 kind: Service
 apiVersion: v1
@@ -10,17 +10,17 @@ metadata:
     system: openstack
     service: metrics
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
-{{% if exportertype['collector'] is defined %}}{{% if exportertype['collector'] == "maia" %}
+{% if exporter_type['collector'] is defined %}{% if exporter_type['collector'] == "maia" %}
   annotations:
     maia.io/scrape: "true"
-    maia.io/port: "{{$.Values.vcenter_exporter.listen_port}}" {{ else if eq $exportertype.collector "prometheus" }}
+    maia.io/port: "{{ vcenter_exporter['listen_port'] }}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {{% endif %}}{{% endif %}}
+    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
 spec:
   selector:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter_listen_port }}
-{{% endif %}}
-{{% endfor %}}
+      port: {{ vcenter_exporter['listen_port'] }}
+{% endfor %}
+{% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -1,4 +1,4 @@
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% if vcenter_exporter['enabled'] == "true" %}
 {% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 kind: Service

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -13,14 +13,14 @@ metadata:
 {% if exporter_type['collector'] is defined %}{% if exporter_type['collector'] == "maia" %}
   annotations:
     maia.io/scrape: "true"
-    maia.io/port: "{{ listen_port }}" {% elif exporter_type['collector'] == "prometheus" %}
+    maia.io/port: "{{ vcenter_exporter['listen_port'] }}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ listen_port }}" {% endif %}{% endif %}
+    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
 spec:
   selector:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ listen_port }}
+      port: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -1,9 +1,5 @@
-{% if vcenter_exporter_enabled == "true" %}
-{% set exporter_types = vcenter_exporter_cluster_exporter_types.split(';') %}
-{% for exporter_type in exporter_types %}
-{% set keyvals = exporter_type.split(',') %}
-{% set exporter_type_name = keyvals[0].split(':')[1] %}
-{% set exporter_type_collector = keyvals[1].split(':')[1] %}
+{% if vcenter_exporter['enabled'] == "true" %}
+{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 kind: Service
 apiVersion: v1
@@ -13,18 +9,18 @@ metadata:
   labels:
     system: openstack
     service: metrics
-    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
-{% if exporter_type_collector is defined %}{% if exporter_type_collector == "maia" %}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+{% if exporter_type['collector'] is defined %}{% if exporter_type['collector'] == "maia" %}
   annotations:
     maia.io/scrape: "true"
-    maia.io/port: "{{ vcenter_exporter_listen_port }}" {% elif exporter_type_collector == "prometheus" %}
+    maia.io/port: "{{ vcenter_exporter['listen_port'] }}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {% endif %}{% endif %}
+    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
 spec:
   selector:
-    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter_listen_port }}
+      port: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -1,5 +1,5 @@
-{% if enabled is defined and enabled == True %}
-{% for exporter_type in cluster_exporter_types %}
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 kind: Service
 apiVersion: v1
@@ -13,14 +13,14 @@ metadata:
 {% if exporter_type['collector'] is defined %}{% if exporter_type['collector'] == "maia" %}
   annotations:
     maia.io/scrape: "true"
-    maia.io/port: "{{ listen_port }}" {% elif exporter_type['collector'] == "prometheus" %}
+    maia.io/port: "{{ vcenter_exporter['listen_port'] }}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ listen_port }}" {% endif %}{% endif %}
+    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
 spec:
   selector:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ listen_port }}
+      port: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -1,5 +1,9 @@
-{% if vcenter_exporter['enabled'] == "true" %}
-{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
+{% if vcenter_exporter_enabled == "true" %}
+{% set exporter_types = vcenter_exporter_cluster_exporter_types.split(';') %}
+{% for exporter_type in exporter_types %}
+{% set keyvals = exporter_type.split(',') %}
+{% set exporter_type_name = keyvals[0].split(':')[1] %}
+{% set exporter_type_collector = keyvals[1].split(':')[1] %}
 ---
 kind: Service
 apiVersion: v1
@@ -9,18 +13,18 @@ metadata:
   labels:
     system: openstack
     service: metrics
-    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
-{% if exporter_type['collector'] is defined %}{% if exporter_type['collector'] == "maia" %}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+{% if exporter_type_collector is defined %}{% if exporter_type_collector == "maia" %}
   annotations:
     maia.io/scrape: "true"
-    maia.io/port: "{{ vcenter_exporter['listen_port'] }}" {% elif exporter_type['collector'] == "prometheus" %}
+    maia.io/port: "{{ vcenter_exporter_listen_port }}" {% elif exporter_type_collector == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
+    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {% endif %}{% endif %}
 spec:
   selector:
-    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter['listen_port'] }}
+      port: {{ vcenter_exporter_listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -1,26 +1,30 @@
-{% if vcenter_exporter['enabled'] == "true" %}
-{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
+{% if vcenter_exporter_enabled == "true" %}
+{% set exporter_types = vcenter_exporter_cluster_exporter_types.split(';') %}
+{% for exporter_type in exporter_types %}
+{% set keyvals = exporter_type.split(',') %}
+{% set exporter_type_name = keyvals[0].split(':')[1] %}
+{% set exporter_type_collector = keyvals[1].split(':')[1] %}
 ---
 kind: Service
 apiVersion: v1
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   namespace: maia
   labels:
     system: openstack
     service: metrics
-    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
-{% if exporter_type['collector'] is defined %}{% if exporter_type['collector'] == "maia" %}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+{% if exporter_type_collector is defined %}{% if exporter_type_collector == "maia" %}
   annotations:
     maia.io/scrape: "true"
-    maia.io/port: "{{ vcenter_exporter['listen_port'] }}" {% elif exporter_type['collector'] == "prometheus" %}
+    maia.io/port: "{{ vcenter_exporter_listen_port }}" {% elif exporter_type_collector == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
+    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {% endif %}{% endif %}
 spec:
   selector:
-    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter['listen_port'] }}
+      port: {{ vcenter_exporter_listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -1,4 +1,5 @@
-{% if vcenter_exporter['enabled'] == "true" %}
+{% if ((vcenter_exporter is defined) and
+       (vcenter_exporter['enabled'] == "true")) %}
 {% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 kind: Service

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -1,0 +1,25 @@
+{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
+{{% for exporter_type in vcenter_exporter_cluster_exporter_types %}}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  namespace: maia
+  labels:
+    system: openstack
+    service: metrics
+    component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  annotations: {{% exportertype['collector'] == "maia" %}
+    maia.io/scrape: "true"
+    maia.io/port: "{{$.Values.vcenter_exporter.listen_port}}" {{ else if eq $exportertype.collector "prometheus" }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {{% endif %}}
+spec:
+  selector:
+    component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  ports:
+    - name: metrics
+      port: {{ vcenter_exporter_listen_port }}
+{{% endif %}}
+{{% endfor %}}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -1,30 +1,26 @@
-{% if vcenter_exporter_enabled == "true" %}
-{% set exporter_types = vcenter_exporter_cluster_exporter_types.split(';') %}
-{% for exporter_type in exporter_types %}
-{% set keyvals = exporter_type.split(',') %}
-{% set exporter_type_name = keyvals[0].split(':')[1] %}
-{% set exporter_type_collector = keyvals[1].split(':')[1] %}
+{% if vcenter_exporter['enabled'] == "true" %}
+{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
 ---
 kind: Service
 apiVersion: v1
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
-  namespace: maia
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+  namespace: monsoon3
   labels:
     system: openstack
     service: metrics
-    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
-{% if exporter_type_collector is defined %}{% if exporter_type_collector == "maia" %}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+{% if exporter_type['collector'] is defined %}{% if exporter_type['collector'] == "maia" %}
   annotations:
     maia.io/scrape: "true"
-    maia.io/port: "{{ vcenter_exporter_listen_port }}" {% elif exporter_type_collector == "prometheus" %}
+    maia.io/port: "{{ vcenter_exporter['listen_port'] }}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {% endif %}{% endif %}
+    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
 spec:
   selector:
-    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter_listen_port }}
+      port: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -13,14 +13,14 @@ metadata:
 {% if exporter_type['collector'] is defined %}{% if exporter_type['collector'] == "maia" %}
   annotations:
     maia.io/scrape: "true"
-    maia.io/port: "{{ vcenter_exporter['listen_port'] }}" {% elif exporter_type['collector'] == "prometheus" %}
+    maia.io/port: "{{ listen_port }}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
+    prometheus.io/port: "{{ listen_port }}" {% endif %}{% endif %}
 spec:
   selector:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter['listen_port'] }}
+      port: {{ listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -1,5 +1,5 @@
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
-{% for exporter_type in vcenter_exporter['cluster_exporter_types'] %}
+{% if enabled is defined and enabled == True %}
+{% for exporter_type in cluster_exporter_types %}
 ---
 kind: Service
 apiVersion: v1
@@ -13,14 +13,14 @@ metadata:
 {% if exporter_type['collector'] is defined %}{% if exporter_type['collector'] == "maia" %}
   annotations:
     maia.io/scrape: "true"
-    maia.io/port: "{{ vcenter_exporter['listen_port'] }}" {% elif exporter_type['collector'] == "prometheus" %}
+    maia.io/port: "{{ listen_port }}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
+    prometheus.io/port: "{{ listen_port }}" {% endif %}{% endif %}
 spec:
   selector:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter['listen_port'] }}
+      port: {{ listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_service.yaml.j2
@@ -4,20 +4,21 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: maia
   labels:
     system: openstack
     service: metrics
-    component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
-  annotations: {{% exportertype['collector'] == "maia" %}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+{{% if exportertype['collector'] is defined %}}{{% if exportertype['collector'] == "maia" %}
+  annotations:
     maia.io/scrape: "true"
     maia.io/port: "{{$.Values.vcenter_exporter.listen_port}}" {{ else if eq $exportertype.collector "prometheus" }}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {{% endif %}}
+    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {{% endif %}}{{% endif %}}
 spec:
   selector:
-    component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
       port: {{ vcenter_exporter_listen_port }}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -14,7 +14,7 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: '{{ vcenter_exporter['listen_port'] }}'
+      listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username }}'
       password: '{{ password }}'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 {% if vcenter_exporter['enabled'] == "true" %}
+=======
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+>>>>>>> adjusted and validated jinja templates
 {% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 apiVersion: v1

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -1,5 +1,5 @@
-{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
-{{% for exporter_type in vcenter_exporter_datacenter_exporter_types %}}
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -14,20 +14,20 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}'.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: '{{ vcenter_exporter_listen_port }}'
+      listen_port: '{{ vcenter_exporter['listen_port'] }}'
       host: '{{ host }}'
       user: '{{ username}}'
       password: '{{ password }}'
       port: 443
-      ignore_ssl: {{ vcenter_exporter_ignore_ssl }}
-      interval: {{vcenter_exporter_interval}}
+      ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
+      interval: {{vcenter_exporter['interval']}}
       log: 'INFO'
-      {{% if vcenter_exporter_shorter_names_regex is defined %}}
-      shorter_names_regex: '{{vcenter_exporter_shorter_names_regex}}'
-      {{% endif %}}
-      {{% if vcenter_exporter_host_match_regex is defined %}}
+      {% if vcenter_exporter['shorter_names_regex'] is defined %}
+      shorter_names_regex: '{{vcenter_exporter['shorter_names_regex']}}'
+      {% endif %}
+      {% if vcenter_exporter['host_match_regex is defined'] %}
       host_match_regex: '{{ name }}'
-      {{% endif %}}
+      {% endif %}
       ignore_match_regex: '(^c_blackbox_|^datapath_|^canary_).*'
       - 'cpu.latency.average'
       - 'cpu.usage.average'
@@ -52,5 +52,5 @@ data:
       - 'virtualDisk.writeIOI.latest'
       - 'virtualDisk.totalReadLatency.average'
       - 'virtualDisk.totalWriteLatency.average'
-{{% endfor %}}
-{{% endif %}}
+{% endfor %}
+{% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -1,0 +1,56 @@
+{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
+{{% for exporter_type in vcenter_exporter_datacenter_exporter_types %}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  namespace: monsoon3
+  labels:
+    system: openstack
+    service: metrics
+    component: configuration
+data:
+  config-{{name}}{{ exporter_type['name'] }}'.yaml: |
+    main:
+      availability_zone: '{{ availability_zone }}'
+      listen_port: '{{ vcenter_exporter_listen_port }}'
+      host: '{{ host }}'
+      user: '{{ username}}'
+      password: '{{ password }}'
+      port: 443
+      ignore_ssl: {{ vcenter_exporter_ignore_ssl }}
+      interval: {{vcenter_exporter_interval}}
+      log: 'INFO'
+      {{% if vcneter_exporter_shorter_names_regex is defined %}}
+      shorter_names_regex: '{{vcenter_exporter_shorter_names_regex}}'
+      {{% endif %}}
+      {{% if vcenter_exporter_host_match_regex is defined %}}
+      host_match_regex: '{{ name }}'
+      {{% endif %}}
+      ignore_match_regex: '(^c_blackbox_|^datapath_|^canary_).*'
+      - 'cpu.latency.average'
+      - 'cpu.usage.average'
+      - 'cpu.usagemhz.average'
+      - 'cpu.wait.summation'
+      - 'disk.usage.average'
+      - 'disk.numberRead.summation'
+      - 'disk.numberWrite.summation'
+      - 'mem.usage.average'
+      - 'net.usage.average'
+      - 'net.bytesRx.average'
+      - 'net.bytesTx.average'
+      - 'net.droppedRx.summation'
+      - 'net.droppedTx.summation'
+      - 'net.errorsRx.summation'
+      - 'net.errorsTx.summation'
+      - 'net.packetsRx.summation'
+      - 'net.packetsTx.summation'
+      - 'virtualDisk.read.average'
+      - 'virtualDisk.write.average'
+      - 'virtualDisk.readIOI.latest'
+      - 'virtualDisk.writeIOI.latest'
+      - 'virtualDisk.totalReadLatency.average'
+      - 'virtualDisk.totalWriteLatency.average'
+{{% endfor %}}
+{{% endif %}}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -11,19 +11,20 @@ metadata:
     service: metrics
     component: configuration
 data:
-  config-{{ name }}-{{ exporter_type['name'] }}'.yaml: |
+  config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: '{{ vcenter_exporter['listen_port'] }}'
+      listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username}}'
       password: '{{ password }}'
-      port: 443
-      ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
+      port: 443{% if vcenter_exporter['ignore_ssl'] == "true" %}
+      ignore_ssl: True{% else %}
+      ignore_ssl: False{% endif %}
       interval: {{vcenter_exporter['interval']}}
       log: 'INFO'
       {% if vcenter_exporter['shorter_names_regex'] is defined %}
-      shorter_names_regex: '{{vcenter_exporter['shorter_names_regex']}}'
+      shorter_names_regex: "{{vcenter_exporter['shorter_names_regex']}}"
       {% endif %}
       {% if vcenter_exporter['host_match_regex is defined'] %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -16,14 +16,14 @@ data:
       availability_zone: '{{ availability_zone }}'
       listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
-      user: '{{ username}}'
+      user: '{{ username }}'
       password: '{{ password }}'
       port: 443
       ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
-      interval: {{vcenter_exporter['interval']}}
+      interval: {{ vcenter_exporter['interval'] }}
       log: 'INFO'
       {% if vcenter_exporter['shorter_names_regex'] is defined %}
-      shorter_names_regex: "{{vcenter_exporter['shorter_names_regex']}}"
+      shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
       {% endif %}
       {% if vcenter_exporter['host_match_regex is defined'] %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -1,31 +1,35 @@
-{% if vcenter_exporter['enabled'] == "true" %}
-{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
+{% if vcenter_exporter_enabled == "true" %}
+{% set exporter_types = vcenter_exporter_datacenter_exporter_types.split(';') %}
+{% for exporter_type in exporter_types %}
+{% set keyvals = exporter_type.split(',') %}
+{% set exporter_type_name = keyvals[0].split(':')[1] %}
+{% set exporter_type_collector = keyvals[1].split(':')[1] %}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   namespace: monsoon3
   labels:
     system: openstack
     service: metrics
     component: configuration
 data:
-  config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
+  config-{{ name }}-{{ exporter_type_name }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: "{{ vcenter_exporter['listen_port'] }}"
+      listen_port: "{{ vcenter_exporter_listen_port }}"
       host: '{{ host }}'
       user: '{{ username }}'
       password: '{{ password }}'
       port: 443
-      ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
-      interval: {{ vcenter_exporter['interval'] }}
+      ignore_ssl: {{ vcenter_exporter_ignore_ssl }}
+      interval: {{ vcenter_exporter_interval }}
       log: 'INFO'
-      {% if vcenter_exporter['shorter_names_regex'] is defined %}
-      shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
+      {% if vcenter_exporter_shorter_names_regex is defined %}
+      shorter_names_regex: "{{ vcenter_exporter_shorter_names_regex }}"
       {% endif %}
-      {% if vcenter_exporter['host_match_regex is defined'] %}
+      {% if vcenter_exporter_host_match_regex is defined %}
       host_match_regex: '{{ name }}'
       {% endif %}
       ignore_match_regex: '(^c_blackbox_|^datapath_|^canary_).*'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -1,4 +1,5 @@
-{% if vcenter_exporter['enabled'] == "true" %}
+{% if ((vcenter_exporter is defined) and
+       (vcenter_exporter['enabled'] == "true")) %}
 {% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 apiVersion: v1

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -1,24 +1,20 @@
-{% if vcenter_exporter_enabled == "true" %}
-{% set exporter_types = vcenter_exporter_datacenter_exporter_types.split(';') %}
-{% for exporter_type in exporter_types %}
-{% set keyvals = exporter_type.split(',') %}
-{% set exporter_type_name = keyvals[0].split(':')[1] %}
-{% set exporter_type_collector = keyvals[1].split(':')[1] %}
+{% if vcenter_exporter['enabled'] == "true" %}
+{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: monsoon3
   labels:
     system: openstack
     service: metrics
     component: configuration
 data:
-  config-{{ name }}-{{ exporter_type_name }}.yaml: |
+  config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: "{{ vcenter_exporter_listen_port }}"
+      listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username }}'
       password: '{{ password }}'
@@ -27,8 +23,8 @@ data:
       ignore_ssl: False{% endif %}
       interval: {{ vcenter_exporter['interval'] }}
       log: 'INFO'
-      {% if vcenter_exporter_shorter_names_regex is defined %}
-      shorter_names_regex: "{{ vcenter_exporter_shorter_names_regex }}"
+      {% if vcenter_exporter['shorter_names_regex'] is defined %}
+      shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
       {% endif %}
       {% if vcenter_exporter['host_match_regex'] is defined %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -4,14 +4,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: monsoon3
   labels:
     system: openstack
     service: metrics
     component: configuration
 data:
-  config-{{name}}{{ exporter_type['name'] }}'.yaml: |
+  config-{{ name }}-{{ exporter_type['name'] }}'.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
       listen_port: '{{ vcenter_exporter_listen_port }}'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -22,7 +22,7 @@ data:
       ignore_ssl: {{ vcenter_exporter_ignore_ssl }}
       interval: {{vcenter_exporter_interval}}
       log: 'INFO'
-      {{% if vcneter_exporter_shorter_names_regex is defined %}}
+      {{% if vcenter_exporter_shorter_names_regex is defined %}}
       shorter_names_regex: '{{vcenter_exporter_shorter_names_regex}}'
       {{% endif %}}
       {{% if vcenter_exporter_host_match_regex is defined %}}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -14,17 +14,16 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: "{{ vcenter_exporter['listen_port'] }}"
+      listen_port: '{{ vcenter_exporter['listen_port'] }}'
       host: '{{ host }}'
       user: '{{ username}}'
       password: '{{ password }}'
-      port: 443{% if vcenter_exporter['ignore_ssl'] == "true" %}
-      ignore_ssl: True{% else %}
-      ignore_ssl: False{% endif %}
+      port: 443
+      ignore_ssl: {{ vcenter_exporter['ignore_ssl'] }}
       interval: {{vcenter_exporter['interval']}}
       log: 'INFO'
       {% if vcenter_exporter['shorter_names_regex'] is defined %}
-      shorter_names_regex: "{{vcenter_exporter['shorter_names_regex']}}"
+      shorter_names_regex: '{{vcenter_exporter['shorter_names_regex']}}'
       {% endif %}
       {% if vcenter_exporter['host_match_regex is defined'] %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -1,38 +1,36 @@
-{% if vcenter_exporter_enabled == "true" %}
-{% set exporter_types = vcenter_exporter_datacenter_exporter_types.split(';') %}
-{% for exporter_type in exporter_types %}
-{% set keyvals = exporter_type.split(',') %}
-{% set exporter_type_name = keyvals[0].split(':')[1] %}
-{% set exporter_type_collector = keyvals[1].split(':')[1] %}
+{% if vcenter_exporter['enabled'] == "true" %}
+{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: monsoon3
   labels:
     system: openstack
     service: metrics
     component: configuration
 data:
-  config-{{ name }}-{{ exporter_type_name }}.yaml: |
+  config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: "{{ vcenter_exporter_listen_port }}"
+      listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username }}'
       password: '{{ password }}'
-      port: 443
-      ignore_ssl: {{ vcenter_exporter_ignore_ssl }}
-      interval: {{ vcenter_exporter_interval }}
+      port: 443{% if vcenter_exporter['ignore_ssl'] == "true" %}
+      ignore_ssl: True{% else %}
+      ignore_ssl: False{% endif %}
+      interval: {{ vcenter_exporter['interval'] }}
       log: 'INFO'
-      {% if vcenter_exporter_shorter_names_regex is defined %}
-      shorter_names_regex: "{{ vcenter_exporter_shorter_names_regex }}"
+      {% if vcenter_exporter['shorter_names_regex'] is defined %}
+      shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
       {% endif %}
-      {% if vcenter_exporter_host_match_regex is defined %}
+      {% if vcenter_exporter['host_match_regex'] is defined %}
       host_match_regex: '{{ name }}'
       {% endif %}
       ignore_match_regex: '(^c_blackbox_|^datapath_|^canary_).*'
+      vm_metrics:
       - 'cpu.latency.average'
       - 'cpu.usage.average'
       - 'cpu.usagemhz.average'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -1,4 +1,4 @@
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% if vcenter_exporter['enabled'] == "true" %}
 {% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 apiVersion: v1
@@ -14,7 +14,7 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: '{{ vcenter_exporter['listen_port'] }}'
+      listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username}}'
       password: '{{ password }}'
@@ -23,7 +23,7 @@ data:
       interval: {{vcenter_exporter['interval']}}
       log: 'INFO'
       {% if vcenter_exporter['shorter_names_regex'] is defined %}
-      shorter_names_regex: '{{vcenter_exporter['shorter_names_regex']}}'
+      shorter_names_regex: "{{vcenter_exporter['shorter_names_regex']}}"
       {% endif %}
       {% if vcenter_exporter['host_match_regex is defined'] %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 {% if vcenter_exporter['enabled'] == "true" %}
-=======
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
->>>>>>> adjusted and validated jinja templates
 {% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 apiVersion: v1

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -1,20 +1,24 @@
-{% if vcenter_exporter['enabled'] == "true" %}
-{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
+{% if vcenter_exporter_enabled == "true" %}
+{% set exporter_types = vcenter_exporter_datacenter_exporter_types.split(';') %}
+{% for exporter_type in exporter_types %}
+{% set keyvals = exporter_type.split(',') %}
+{% set exporter_type_name = keyvals[0].split(':')[1] %}
+{% set exporter_type_collector = keyvals[1].split(':')[1] %}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   namespace: monsoon3
   labels:
     system: openstack
     service: metrics
     component: configuration
 data:
-  config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
+  config-{{ name }}-{{ exporter_type_name }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: "{{ vcenter_exporter['listen_port'] }}"
+      listen_port: "{{ vcenter_exporter_listen_port }}"
       host: '{{ host }}'
       user: '{{ username }}'
       password: '{{ password }}'
@@ -23,8 +27,8 @@ data:
       ignore_ssl: False{% endif %}
       interval: {{ vcenter_exporter['interval'] }}
       log: 'INFO'
-      {% if vcenter_exporter['shorter_names_regex'] is defined %}
-      shorter_names_regex: "{{ vcenter_exporter['shorter_names_regex'] }}"
+      {% if vcenter_exporter_shorter_names_regex is defined %}
+      shorter_names_regex: "{{ vcenter_exporter_shorter_names_regex }}"
       {% endif %}
       {% if vcenter_exporter['host_match_regex'] is defined %}
       host_match_regex: '{{ name }}'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_configmap.yaml.j2
@@ -14,7 +14,7 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
-      listen_port: "{{ vcenter_exporter['listen_port'] }}"
+      listen_port: '{{ vcenter_exporter['listen_port'] }}'
       host: '{{ host }}'
       user: '{{ username }}'
       password: '{{ password }}'

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -1,10 +1,14 @@
-{% if vcenter_exporter['enabled'] == "true" %}
-{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
+{% if vcenter_exporter_enabled == "true" %}
+{% set exporter_types = vcenter_exporter_datacenter_exporter_types.split(';') %}
+{% for exporter_type in exporter_types %}
+{% set keyvals = exporter_type.split(',') %}
+{% set exporter_type_name = keyvals[0].split(':')[1] %}
+{% set exporter_type_collector = keyvals[1].split(':')[1] %}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   namespace: monsoon3
   labels:
     system: openstack
@@ -20,32 +24,32 @@ spec:
   template:
     metadata:
       labels:
-        component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+        component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
     spec:
       nodeSelector:
         zone: farm
       volumes:
         - name: maia-etc
           configMap:
-            name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+            name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
+          image: {{ vcenter_exporter_docker_repo }}/vcenter-exporter:{{ vcenter_exporter_image_version | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
           args:
             - /vcenter-exporter/vcenter-exporter.py
             - -c
-            - /maia-etc/config-{{ name }}-{{ exporter_type['name'] }}.yaml
+            - /maia-etc/config-{{ name }}-{{ exporter_type_name }}.yaml
             - -t
-            - {{ exporter_type['name'] }}
+            - {{ exporter_type_name }}
           volumeMounts:
             - mountPath: /maia-etc
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ vcenter_exporter['listen_port'] }}
+              containerPort: {{ vcenter_exporter_listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -1,14 +1,10 @@
-{% if vcenter_exporter_enabled == "true" %}
-{% set exporter_types = vcenter_exporter_datacenter_exporter_types.split(';') %}
-{% for exporter_type in exporter_types %}
-{% set keyvals = exporter_type.split(',') %}
-{% set exporter_type_name = keyvals[0].split(':')[1] %}
-{% set exporter_type_collector = keyvals[1].split(':')[1] %}
+{% if vcenter_exporter['enabled'] == "true" %}
+{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: monsoon3
   labels:
     system: openstack
@@ -24,32 +20,32 @@ spec:
   template:
     metadata:
       labels:
-        component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+        component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
     spec:
       nodeSelector:
         zone: farm
       volumes:
         - name: maia-etc
           configMap:
-            name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+            name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ vcenter_exporter_docker_repo }}/vcenter-exporter:{{ vcenter_exporter_image_version | replace ("string:", "") }}
+          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
           args:
             - /vcenter-exporter/vcenter-exporter.py
             - -c
-            - /maia-etc/config-{{ name }}-{{ exporter_type_name }}.yaml
+            - /maia-etc/config-{{ name }}-{{ exporter_type['name'] }}.yaml
             - -t
-            - {{ exporter_type_name }}
+            - {{ exporter_type['name'] }}
           volumeMounts:
             - mountPath: /maia-etc
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ vcenter_exporter_listen_port }}
+              containerPort: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -4,7 +4,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: monsoon3
   labels:
     system: openstack
@@ -20,14 +20,14 @@ spec:
   template:
     metadata:
       labels:
-        component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+        component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
     spec:
       nodeSelector:
         zone: farm
       volumes:
         - name: maia-etc
           configMap:
-            name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+            name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
@@ -38,7 +38,7 @@ spec:
           args:
             - /vcenter-exporter/vcenter-exporter.py
             - -c
-            - /maia-etc/config-{{ name }}{{ exporter_type['name'] }}.yaml
+            - /maia-etc/config-{{ name }}-{{ exporter_type['name'] }}.yaml
             - -t
             - {{ exporter_type['name'] }}
           volumeMounts:

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ docker_repo}}/vcenter-exporter:{{ image_version | replace ("string:", "") }}
+          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -46,6 +46,6 @@ spec:
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ listen_port }}
+              containerPort: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 {% if enabled is defined and enabled == True %}
 {% for exporter_type in datacenter_exporter_types %}
+=======
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
+>>>>>>> adjusted and validated jinja templates
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -31,7 +36,7 @@ spec:
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ docker_repo}}/vcenter-exporter:{{ image_version | replace ("string:", "") }}
+          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -46,6 +51,6 @@ spec:
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ listen_port }}
+              containerPort: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -1,5 +1,5 @@
-{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
-{{% for exporter_type in vcenter_exporter_datacenter_exporter_types %}}
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ vcenter_exporter_docker_repo}}/vcenter-exporter:{{ vcenter_exporter_image | replace ("string:", "") }}
+          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -46,6 +46,6 @@ spec:
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ vcenter_exporter_listen_port }}
-{{% endfor %}}
-{{% endif %}}
+              containerPort: {{ vcenter_exporter['listen_port'] }}
+{% endfor %}
+{% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
+          image: {{ docker_repo}}/vcenter-exporter:{{ image_version | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -46,6 +46,6 @@ spec:
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ vcenter_exporter['listen_port'] }}
+              containerPort: {{ listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -1,0 +1,51 @@
+{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
+{{% for exporter_type in vcenter_exporter_datacenter_exporter_types %}}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  namespace: monsoon3
+  labels:
+    system: openstack
+    service: metrics
+
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+    spec:
+      nodeSelector:
+        zone: farm
+      volumes:
+        - name: maia-etc
+          configMap:
+            name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+      containers:
+        - name: vcenter-exporter
+          # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
+          image: {{ vcenter_exporter_docker_repo}}/vcenter-exporter:{{ vcenter_exporter_image | replace ("string:", "") }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - python
+          args:
+            - /vcenter-exporter/vcenter-exporter.py
+            - -c
+            - /maia-etc/config-{{ name }}{{ exporter_type['name'] }}.yaml
+            - -t
+            - {{ exporter_type['name'] }}
+          volumeMounts:
+            - mountPath: /maia-etc
+              name: maia-etc
+          ports:
+            - name: metrics
+              containerPort: {{ vcenter_exporter_listen_port }}
+{{% endfor %}}
+{{% endif %}}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -1,5 +1,5 @@
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
-{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
+{% if enabled is defined and enabled == True %}
+{% for exporter_type in datacenter_exporter_types %}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: vcenter-exporter
           # remove the "string:" prefix which is used to prevent helm's --set option from reformatting plain numbers into floats in scientific notation
-          image: {{ vcenter_exporter['docker_repo']}}/vcenter-exporter:{{ vcenter_exporter['image_version'] | replace ("string:", "") }}
+          image: {{ docker_repo}}/vcenter-exporter:{{ image_version | replace ("string:", "") }}
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -46,6 +46,6 @@ spec:
               name: maia-etc
           ports:
             - name: metrics
-              containerPort: {{ vcenter_exporter['listen_port'] }}
+              containerPort: {{ listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -1,4 +1,5 @@
-{% if vcenter_exporter['enabled'] == "true" %}
+{% if ((vcenter_exporter is defined) and
+       (vcenter_exporter['enabled'] == "true")) %}
 {% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 apiVersion: extensions/v1beta1

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_deployment.yaml.j2
@@ -1,10 +1,5 @@
-<<<<<<< HEAD
-{% if enabled is defined and enabled == True %}
-{% for exporter_type in datacenter_exporter_types %}
-=======
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% if vcenter_exporter['enabled'] == "true" %}
 {% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
->>>>>>> adjusted and validated jinja templates
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -1,4 +1,4 @@
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% if vcenter_exporter['enabled'] == "true" %}
 {% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 kind: Service

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -1,4 +1,5 @@
-{% if vcenter_exporter['enabled'] == "true" %}
+{% if ((vcenter_exporter is defined) and
+       (vcenter_exporter['enabled'] == "true")) %}
 {% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 kind: Service

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -1,5 +1,5 @@
-{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
-{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
+{% if enabled is defined and enabled == True %}
+{% for exporter_type in datacenter_exporter_types %}
 ---
 kind: Service
 apiVersion: v1
@@ -12,14 +12,14 @@ metadata:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   annotations: {% if exporter_type['collector'] == "maia" %}
     maia.io/scrape: "true"
-    maia.io/port: "{{ vcenter_exporter['listen_port']}}" {% elif exporter_type['collector'] == "prometheus" %}
+    maia.io/port: "{{ listen_port}}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}
+    prometheus.io/port: "{{ listen_port }}" {% endif %}
 spec:
   selector:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter['listen_port'] }}
+      port: {{ listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -10,7 +10,7 @@ metadata:
     system: openstack
     service: metrics
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
-  annotations: {%if exporter_type['collector'] == "maia" %}
+  annotations: {% if exporter_type['collector'] == "maia" %}
     maia.io/scrape: "true"
     maia.io/port: "{{ vcenter_exporter['listen_port']}}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -21,6 +21,6 @@ spec:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter['listen_port'] }}
+      port: {{ listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -21,6 +21,6 @@ spec:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ listen_port }}
+      port: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -1,25 +1,29 @@
-{% if vcenter_exporter['enabled'] == "true" %}
-{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
+{% if vcenter_exporter_enabled == "true" %}
+{% set exporter_types = vcenter_exporter_datacenter_exporter_types.split(';') %}
+{% for exporter_type in exporter_types %}
+{% set keyvals = exporter_type.split(',') %}
+{% set exporter_type_name = keyvals[0].split(':')[1] %}
+{% set exporter_type_collector = keyvals[1].split(':')[1] %}
 ---
 kind: Service
 apiVersion: v1
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   namespace: maia
   labels:
     system: openstack
     service: metrics
-    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
-  annotations: {% if exporter_type['collector'] == "maia" %}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+  annotations: {% if exporter_type_collector == "maia" %}
     maia.io/scrape: "true"
-    maia.io/port: "{{ vcenter_exporter['listen_port']}}" {% elif exporter_type['collector'] == "prometheus" %}
+    maia.io/port: "{{ vcenter_exporter_listen_port }}" {% elif exporter_type_collector == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}
+    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {% endif %}
 spec:
   selector:
-    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter['listen_port'] }}
+      port: {{ vcenter_exporter_listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -1,9 +1,5 @@
-{% if vcenter_exporter_enabled == "true" %}
-{% set exporter_types = vcenter_exporter_datacenter_exporter_types.split(';') %}
-{% for exporter_type in exporter_types %}
-{% set keyvals = exporter_type.split(',') %}
-{% set exporter_type_name = keyvals[0].split(':')[1] %}
-{% set exporter_type_collector = keyvals[1].split(':')[1] %}
+{% if vcenter_exporter['enabled'] == "true" %}
+{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 kind: Service
 apiVersion: v1
@@ -22,9 +18,9 @@ metadata:
     prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
 spec:
   selector:
-    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter_listen_port }}
+      port: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -1,5 +1,5 @@
-{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
-{{% for exporter_type in vcenter_exporter_datacenter_exporter_types %}}
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 kind: Service
 apiVersion: v1
@@ -10,16 +10,16 @@ metadata:
     system: openstack
     service: metrics
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
-  annotations: {{% exportertype['collector'] == "maia" %}
+  annotations: {%if exporter_type['collector'] == "maia" %}
     maia.io/scrape: "true"
-    maia.io/port: "{{$.Values.vcenter_exporter.listen_port}}" {{ else if eq $exportertype.collector "prometheus" }}
+    maia.io/port: "{{ vcenter_exporter['listen_port']}}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {{% endif %}}
+    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}
 spec:
   selector:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter_listen_port }}
-{{% endfor %}}
-{{% endif %}}
+      port: {{ vcenter_exporter['listen_port'] }}
+{% endfor %}
+{% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -1,5 +1,5 @@
-{% if enabled is defined and enabled == True %}
-{% for exporter_type in datacenter_exporter_types %}
+{% if vcenter_exporter['enabled'] is defined and vcenter_exporter['enabled'] == True %}
+{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 kind: Service
 apiVersion: v1
@@ -10,16 +10,16 @@ metadata:
     system: openstack
     service: metrics
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
-  annotations: {% if exporter_type['collector'] == "maia" %}
+  annotations: {%if exporter_type['collector'] == "maia" %}
     maia.io/scrape: "true"
-    maia.io/port: "{{ listen_port}}" {% elif exporter_type['collector'] == "prometheus" %}
+    maia.io/port: "{{ vcenter_exporter['listen_port']}}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ listen_port }}" {% endif %}
+    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}
 spec:
   selector:
     component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ listen_port }}
+      port: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -4,12 +4,12 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   namespace: maia
   labels:
     system: openstack
     service: metrics
-    component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   annotations: {{% exportertype['collector'] == "maia" %}
     maia.io/scrape: "true"
     maia.io/port: "{{$.Values.vcenter_exporter.listen_port}}" {{ else if eq $exportertype.collector "prometheus" }}
@@ -17,7 +17,7 @@ metadata:
     prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {{% endif %}}
 spec:
   selector:
-    component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
       port: {{ vcenter_exporter_listen_port }}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -1,5 +1,9 @@
-{% if vcenter_exporter['enabled'] == "true" %}
-{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
+{% if vcenter_exporter_enabled == "true" %}
+{% set exporter_types = vcenter_exporter_datacenter_exporter_types.split(';') %}
+{% for exporter_type in exporter_types %}
+{% set keyvals = exporter_type.split(',') %}
+{% set exporter_type_name = keyvals[0].split(':')[1] %}
+{% set exporter_type_collector = keyvals[1].split(':')[1] %}
 ---
 kind: Service
 apiVersion: v1
@@ -18,9 +22,9 @@ metadata:
     prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
 spec:
   selector:
-    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter['listen_port'] }}
+      port: {{ vcenter_exporter_listen_port }}
 {% endfor %}
 {% endif %}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -1,0 +1,25 @@
+{{% if vcenter_exporter_enabled is defined and vcenter_exporter_enabled == True %}}
+{{% for exporter_type in vcenter_exporter_datacenter_exporter_types %}}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  namespace: maia
+  labels:
+    system: openstack
+    service: metrics
+    component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  annotations: {{% exportertype['collector'] == "maia" %}
+    maia.io/scrape: "true"
+    maia.io/port: "{{$.Values.vcenter_exporter.listen_port}}" {{ else if eq $exportertype.collector "prometheus" }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {{% endif %}}
+spec:
+  selector:
+    component: vcenter-exporter-{{ name }}{{ exporter_type['name'] }}
+  ports:
+    - name: metrics
+      port: {{ vcenter_exporter_listen_port }}
+{{% endfor %}}
+{{% endif %}}

--- a/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_datacenter_exporter_service.yaml.j2
@@ -1,29 +1,26 @@
-{% if vcenter_exporter_enabled == "true" %}
-{% set exporter_types = vcenter_exporter_datacenter_exporter_types.split(';') %}
-{% for exporter_type in exporter_types %}
-{% set keyvals = exporter_type.split(',') %}
-{% set exporter_type_name = keyvals[0].split(':')[1] %}
-{% set exporter_type_collector = keyvals[1].split(':')[1] %}
+{% if vcenter_exporter['enabled'] == "true" %}
+{% for exporter_type in vcenter_exporter['datacenter_exporter_types'] %}
 ---
 kind: Service
 apiVersion: v1
 metadata:
-  name: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
-  namespace: maia
+  name: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+  namespace: monsoon3
   labels:
     system: openstack
     service: metrics
-    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
-  annotations: {% if exporter_type_collector == "maia" %}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
+{% if exporter_type['collector'] is defined %}{% if exporter_type['collector'] == "maia" %}
+  annotations:
     maia.io/scrape: "true"
-    maia.io/port: "{{ vcenter_exporter_listen_port }}" {% elif exporter_type_collector == "prometheus" %}
+    maia.io/port: "{{ vcenter_exporter['listen_port'] }}" {% elif exporter_type['collector'] == "prometheus" %}
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ vcenter_exporter_listen_port }}" {% endif %}
+    prometheus.io/port: "{{ vcenter_exporter['listen_port'] }}" {% endif %}{% endif %}
 spec:
   selector:
-    component: vcenter-exporter-{{ name }}-{{ exporter_type_name }}
+    component: vcenter-exporter-{{ name }}-{{ exporter_type['name'] }}
   ports:
     - name: metrics
-      port: {{ vcenter_exporter_listen_port }}
+      port: {{ vcenter_exporter['listen_port'] }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Changes to enable vcenter-exporter instantiated from vcenter-operator.  Changes in openstack-helm should have no effect until a vcenter-exporter is defined in a secrets file with the enabled flag set to "true".