### PR TITLE
Use operator exposed cluster_name in configmap

### DIFF
--- a/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
+++ b/openstack/vcenter-operator/vcenter_cluster_exporter_configmap.yaml.j2
@@ -15,6 +15,7 @@ data:
   config-{{ name }}-{{ exporter_type['name'] }}.yaml: |
     main:
       availability_zone: '{{ availability_zone }}'
+      cluster_name: '{{ cluster_name }}'
       listen_port: "{{ vcenter_exporter['listen_port'] }}"
       host: '{{ host }}'
       user: '{{ username }}'


### PR DESCRIPTION
Using this exposed variable will allow us to skip hostname regex checks and check directly if the VM belongs to the correct cluster.