### PR TITLE
increase timeouts to fix glance img upload via ingress

### DIFF
--- a/glance/templates/ingress.yaml
+++ b/glance/templates/ingress.yaml
@@ -8,10 +8,10 @@ metadata:
     type: api
     component: glance
   annotations:
-     ingress.kubernetes.io/proxy-request-buffering: "off"
-     {{- if .Values.vice_president }}
-     vice-president: "true"
-     {{- end }}
+    ingress.kubernetes.io/proxy-request-buffering: "off"
+    ingress.kubernetes.io/proxy-read-timeout: "600"
+    ingress.kubernetes.io/proxy-send-timeout: "600"
+    vice-president: {{ default false .Values.ingress.vice_president | quote }}
 spec:
   tls:
     - secretName: tls-{{ include "glance_api_endpoint_host_public" . | replace "." "-" }}


### PR DESCRIPTION
Disabling the request buffering is not enough. Increasing the timeouts seems to fix the glance image upload issue. Tested successfully multiple times with ~5GiB images in staging. Testing again tomorrow with 20GiB images. Besides: any objections @fwiesel? 