### PR TITLE
Ironic seed: Cleanup role/role assignments

### DIFF
--- a/ironic/templates/seed.yaml
+++ b/ironic/templates/seed.yaml
@@ -139,6 +139,8 @@ spec:
       - project: service
         role: cloud_baremetal_admin
       - project: service
+        role: cloud_image_admin
+      - project: service
         role: swiftreseller
   - name: ccadmin
     projects:

--- a/ironic/templates/seed.yaml
+++ b/ironic/templates/seed.yaml
@@ -6,6 +6,9 @@ spec:
   requires:
     - monsoon3/domain-default-seed
     - monsoon3/domain-ccadmin-seed
+    - monsoon3/nova-seed
+    - monsoon3/neutron-seed
+    - swift/swift-seed
 
   roles:
     - cloud_baremetal_admin

--- a/ironic/templates/seed.yaml
+++ b/ironic/templates/seed.yaml
@@ -11,9 +11,7 @@ spec:
     - cloud_baremetal_admin
     - baremetal_admin
     - baremetal_viewer
-    - cloud_compute_admin
-    - cloud_image_admin
-    - cloud_network_admin
+    - cloud_image_admin  # TODO: That should move to the glance seed
 
   services:
   - name: ironic


### PR DESCRIPTION
* Assign `cloud_image_admin` to ironic user
* Remove `cloud_compute_admin` -> comes from openstack-helm/nova/seed
* Remove `cloud_network_admin` -> comes from helm-charts/neutron/seed
* `cloud_image_admin` -> should go to a tbd glance seed