### PR TITLE
bump backup image version

### DIFF
--- a/mariadb/values.yaml
+++ b/mariadb/values.yaml
@@ -16,7 +16,7 @@ backup:
   metrics: false
   interval_full: 1 days
   interval_incr: 1 hours
-  image_version: v0.5.7
+  image_version: v0.5.14
   os_password: DEFINED-IN-REGION-SECRETS
   os_username: db_backup
   os_user_domain: Default

--- a/postgres/values.yaml
+++ b/postgres/values.yaml
@@ -66,7 +66,7 @@ backup:
   metrics: false
   interval_full: 1 hours
 #  interval_incr: NOT-USED-CURRENT
-  image_version: v0.5.7
+  image_version: v0.5.14
   os_password: DEFINED-IN-REGION-SECRETS
   os_username: db_backup
   os_user_domain: Default


### PR DESCRIPTION
backup-tools:v0.5.14 has the following improvements for the backup-restore utility:
* backup-restore does not connect itself to the to be restored database anymore, which
  caused the `DROP DATABASE IF EXISTS` statement to fail
* backup-restore prints out the executed statements from the dump file,
  allowing to track down possible issues
* backup-restore keeps the restored dumpfile in `/tmp/newbackup<random> for possible
  manual reexecution